### PR TITLE
Fixed error when building from schema with complex model properties

### DIFF
--- a/packages/typescript-fetch-client/templates/modelGeneric.hbs
+++ b/packages/typescript-fetch-client/templates/modelGeneric.hbs
@@ -12,7 +12,7 @@ export interface {{className name}} {{#if parents}}extends {{#each parents}}{{{n
 {{/if}}
 {{#each properties}}
 	{{>frag/propertyDocumentation memberOf=../name}}
-	{{#if readOnly}}readonly {{/if}}{{serializedName}}{{#unless required}}?{{/unless}}: {{{nativeType.serializedType}}};
+	{{#if readOnly}}readonly {{/if}}'{{serializedName}}'{{#unless required}}?{{/unless}}: {{{nativeType.serializedType}}};
 {{/each}}
 }
 {{>modelNestedModels}}

--- a/packages/typescript-fetch-client2/templates/modelGeneric.hbs
+++ b/packages/typescript-fetch-client2/templates/modelGeneric.hbs
@@ -12,7 +12,7 @@ export interface {{className name}} {{#if parents}}extends {{#each parents}}{{{n
 {{/if}}
 {{#each properties}}
 	{{>frag/propertyDocumentation memberOf=../name}}
-	{{#if readOnly}}readonly {{/if}}{{serializedName}}{{#unless required}}?{{/unless}}: {{{nativeType.serializedType}}};
+	{{#if readOnly}}readonly {{/if}}'{{serializedName}}'{{#unless required}}?{{/unless}}: {{{nativeType.serializedType}}};
 {{/each}}
 }
 {{>modelNestedModels}}


### PR DESCRIPTION
Changes needed to support properties like 'some:property' widely used in API design. See [HAL format](https://stateless.group/hal_specification.html) for example.