### PR TITLE
Replace `encodeURIComponent` with `encodeURI`

### DIFF
--- a/packages/typescript-fetch-client/templates/api.hbs
+++ b/packages/typescript-fetch-client/templates/api.hbs
@@ -1,7 +1,7 @@
 {{>header}}
 
 import { Configuration } from "./configuration";
-import { BASE_PATH, COLLECTION_FORMATS, FetchAPI, FetchArgs, BaseAPI, RequiredError, defaultFetch } from "./runtime";
+import { BASE_PATH, COLLECTION_FORMATS, encodeURIPathSegment, FetchAPI, FetchArgs, BaseAPI, RequiredError, defaultFetch } from "./runtime";
 import { Api } from "./models";
 {{#ifeq dateApproach 'blind-date'}}
 import { LocalDateString, LocalTimeString, LocalDateTimeString, OffsetDateTimeString } from 'blind-date';
@@ -27,7 +27,7 @@ export const {{className name}}ApiFetchParamCreator = function (configuration?: 
 	{{>frag/validateParameter operation=..}}
 	{{/with}}
 			let localVarPath = `{{{../path}}}{{{path}}}`{{#each pathParams}}
-				.replace('{{safe '{'}}{{{serializedName}}}{{safe '}'}}', encodeURIComponent(String({{identifier name}}))){{/each}};
+				.replace('{{safe '{'}}{{{serializedName}}}{{safe '}'}}', encodeURIPathSegment(String({{identifier name}}))){{/each}};
 			const localVarPathQueryStart = localVarPath.indexOf("?");
 			const localVarRequestOptions: RequestInit = Object.assign({ method: '{{httpMethod}}' }, options);
 			const localVarHeaderParameter: Headers = options.headers ? new Headers(options.headers) : new Headers();

--- a/packages/typescript-fetch-client/templates/runtime.hbs
+++ b/packages/typescript-fetch-client/templates/runtime.hbs
@@ -69,3 +69,51 @@ export class RequiredError extends Error {
 		this.name = "RequiredError";
 	}
 }
+
+/* The following characters are legal in URL path segments, but are encoded by `encodeURIComponent`
+
+	From RFC 3986: https://datatracker.ietf.org/doc/html/rfc3986
+	segment       = *pchar
+	pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+	pct-encoded   = "%" HEXDIG HEXDIG
+	unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
+	sub-delims    = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+
+*/
+const URL_PATH_SEGMENT_CHARS = [
+/* -- sub-delims -- */
+/*	'!',  - Not needed, as this is not encoded by `encodeURIComponent` */
+	'$',
+	'&',
+/*	'\'', - Not needed, as this is not encoded by `encodeURIComponent` */
+/*	'(',  - Not needed, as this is not encoded by `encodeURIComponent` */
+/*	')',  - Not needed, as this is not encoded by `encodeURIComponent` */
+/*	'*',  - Not needed, as this is not encoded by `encodeURIComponent` */
+	'+',
+	',',
+	';',
+	'=',
+/* -- specific pchars -- */
+	':',
+	'@',
+]
+const URL_PATH_SEGMENT_CHAR_MAP = URL_PATH_SEGMENT_CHARS.reduce((acc: Record<string, string>, char) => {
+	acc[encodeURIComponent(char)] = char
+	return acc
+}, {})
+
+/**
+ * Similar to `encodeURIComponent`, but does not encode certain characters that are specifically legal
+ * in URL path segments, according to RFC 3986: https://datatracker.ietf.org/doc/html/rfc3986
+ * 
+ * See {@link URL_PATH_SEGMENT_CHARS} for the list of characters that are not encoded.
+ * 
+ * @export
+ */
+export function encodeURIPathSegment(segment: string) {
+	let result = encodeURIComponent(segment)
+	Object.entries(URL_PATH_SEGMENT_CHAR_MAP).forEach(([encoded, char]) => {
+		result = result.replaceAll(encoded, char)
+	})
+	return result
+}

--- a/packages/typescript-fetch-client2/templates/api.hbs
+++ b/packages/typescript-fetch-client2/templates/api.hbs
@@ -1,7 +1,7 @@
 {{>header}}
 
 import { Configuration } from "./configuration";
-import { BASE_PATH, COLLECTION_FORMATS, FetchAPI, FetchArgs, BaseAPI, RequiredError, defaultFetch } from "./runtime";
+import { BASE_PATH, COLLECTION_FORMATS, encodeURIPathSegment, FetchAPI, FetchArgs, BaseAPI, RequiredError, defaultFetch } from "./runtime";
 import { Api } from "./models";
 {{#ifeq dateApproach 'blind-date'}}
 import { LocalDateString, LocalTimeString, LocalDateTimeString, OffsetDateTimeString } from 'blind-date';
@@ -49,7 +49,7 @@ export const {{className name}}ApiFetchParamCreator = function (configuration?: 
 			{{/with}}
 
 			let localVarPath = `{{{../path}}}{{{path}}}`{{#each pathParams}}
-				.replace('{{safe '{'}}{{{serializedName}}}{{safe '}'}}', encodeURIComponent(String({{../_parameterPrefix}}{{identifier name}}))){{/each}};
+				.replace('{{safe '{'}}{{{serializedName}}}{{safe '}'}}', encodeURIPathSegment(String({{../_parameterPrefix}}{{identifier name}}))){{/each}};
 			const localVarPathQueryStart = localVarPath.indexOf("?");
 			const localVarRequestOptions: RequestInit = Object.assign({ method: '{{httpMethod}}' }, options);
 			const localVarHeaderParameter: Headers = options.headers ? new Headers(options.headers) : new Headers();

--- a/packages/typescript-fetch-client2/templates/runtime.hbs
+++ b/packages/typescript-fetch-client2/templates/runtime.hbs
@@ -69,3 +69,51 @@ export class RequiredError extends Error {
 		this.name = "RequiredError";
 	}
 }
+
+/* The following characters are legal in URL path segments, but are encoded by `encodeURIComponent`
+
+	From RFC 3986: https://datatracker.ietf.org/doc/html/rfc3986
+	segment       = *pchar
+	pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+	pct-encoded   = "%" HEXDIG HEXDIG
+	unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
+	sub-delims    = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+
+*/
+const URL_PATH_SEGMENT_CHARS = [
+/* -- sub-delims -- */
+/*	'!',  - Not needed, as this is not encoded by `encodeURIComponent` */
+	'$',
+	'&',
+/*	'\'', - Not needed, as this is not encoded by `encodeURIComponent` */
+/*	'(',  - Not needed, as this is not encoded by `encodeURIComponent` */
+/*	')',  - Not needed, as this is not encoded by `encodeURIComponent` */
+/*	'*',  - Not needed, as this is not encoded by `encodeURIComponent` */
+	'+',
+	',',
+	';',
+	'=',
+/* -- specific pchars -- */
+	':',
+	'@',
+]
+const URL_PATH_SEGMENT_CHAR_MAP = URL_PATH_SEGMENT_CHARS.reduce((acc: Record<string, string>, char) => {
+	acc[encodeURIComponent(char)] = char
+	return acc
+}, {})
+
+/**
+ * Similar to `encodeURIComponent`, but does not encode certain characters that are specifically legal
+ * in URL path segments, according to RFC 3986: https://datatracker.ietf.org/doc/html/rfc3986
+ * 
+ * See {@link URL_PATH_SEGMENT_CHARS} for the list of characters that are not encoded.
+ * 
+ * @export
+ */
+export function encodeURIPathSegment(segment: string) {
+	let result = encodeURIComponent(segment)
+	Object.entries(URL_PATH_SEGMENT_CHAR_MAP).forEach(([encoded, char]) => {
+		result = result.replaceAll(encoded, char)
+	})
+	return result
+}


### PR DESCRIPTION
Replace `encodeURIComponent` in the *ApiFetchParamCreator generated code with `encodeURI` so we get the correct encoding rules for the path parameters.