### PR TITLE
typescript-fetch-client2: Never throw errors from generated api client

### DIFF
--- a/.changeset/tidy-bananas-tie.md
+++ b/.changeset/tidy-bananas-tie.md
@@ -1,0 +1,6 @@
+---
+"@openapi-generator-plus/typescript-fetch-client-generator2": minor
+---
+
+Never throw errors from the generated API endpoints. Instead, these are handled using two new 
+response status types: `'error'` and `'undocumented'`.

--- a/packages/typescript-fetch-client2/README.md
+++ b/packages/typescript-fetch-client2/README.md
@@ -40,6 +40,28 @@ the default configuration for specific groups of endpoints:
 the final parameter to an endpoint functions. This configuration is used instead of the default 
 configuration.
 
+### Error Handling
+
+The generated endpoints enforce that your application can handle all errors returned by your 
+API through 
+[discriminated response types](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions) 
+on the `status` field. In addition to the responses defined in your OpenAPI specification, there are
+two other response types:
+
+| `status`       | Meaning |
+|----------------|---------|
+| `'undocumented'` | The response contained an HTTP status code, or `Content-Type` not defined in your OpenAPI specification. |
+| `'error'`        | An error was thrown in the generated endpoint. This could be due to a network error, a malformed response, a missing required parameter, etc. |
+
+> [!TIP]
+> If necessary, you can differentiate between these special responses and ones in your OpenAPI 
+> specification using `typeof`:
+> ```ts
+> if (typeof response.status === 'number') {
+> 	// This response is defined in your OpenAPI specification!	
+> }
+> ```
+
 ### Tree Shaking
 
 If you're not using every endpoint in your API, 

--- a/packages/typescript-fetch-client2/templates/api.hbs
+++ b/packages/typescript-fetch-client2/templates/api.hbs
@@ -160,20 +160,37 @@ export function paramCreator(configuration?: Configuration) {
 {{>frag/operationDocumentation}}
 {{#if (gt (count parameters) 1)}}
 export async function {{identifier name}}(__params: {{className ../name}}Api.{{{parametersInterfaceName}}}, {{#if requestBody.nativeType}}{{#with requestBody}}{{>frag/parameter}}, {{/with}}{{/if}}options?: RequestInit, configuration?: Configuration): Promise<{{{className ../name}}}Api.{{{className name}}}Response> {
-	configuration ??= getDefaultConfiguration(); 
-	const localVarFetchArgs = {{identifier name}}ParamCreator(__params, {{#if requestBody.nativeType}}{{#with requestBody}}{{identifier name}}, {{/with}}{{/if}}options, configuration);
+	try {
+		configuration ??= getDefaultConfiguration(); 
+		const localVarFetchArgs = {{identifier name}}ParamCreator(__params, {{#if requestBody.nativeType}}{{#with requestBody}}{{identifier name}}, {{/with}}{{/if}}options, configuration);
 {{else}}
 export async function {{identifier name}}({{#each parameters}}{{>frag/parameter}}, {{/each}}{{#if requestBody.nativeType}}{{#with requestBody}}{{>frag/parameter}}, {{/with}}{{/if}}options?: RequestInit, configuration?: Configuration): Promise<{{{className ../name}}}Api.{{{className name}}}Response> {
-	configuration ??= getDefaultConfiguration(); 
-	const localVarFetchArgs = {{identifier name}}ParamCreator({{#each parameters}}{{identifier name}}, {{/each}}{{#if requestBody.nativeType}}{{#with requestBody}}{{identifier name}}, {{/with}}{{/if}}options, configuration);
+	try {
+		configuration ??= getDefaultConfiguration(); 
+		const localVarFetchArgs = {{identifier name}}ParamCreator({{#each parameters}}{{identifier name}}, {{/each}}{{#if requestBody.nativeType}}{{#with requestBody}}{{identifier name}}, {{/with}}{{/if}}options, configuration);
 {{/if}}
-	const response = await configuration.fetch(configuration.baseUri + localVarFetchArgs.url, localVarFetchArgs.options)
-	const contentType = response.headers.get('Content-Type');
-	const mimeType = contentType ? contentType.replace(/;.*/, '') : undefined;
-	
-	{{#each responses}}
-	{{#unless isCatchAll}}
-	if (response.status === {{code}}) {
+		const response = await configuration.fetch(configuration.baseUri + localVarFetchArgs.url, localVarFetchArgs.options)
+		const contentType = response.headers.get('Content-Type');
+		const mimeType = contentType ? contentType.replace(/;.*/, '') : undefined;
+		
+		{{#each responses}}
+		{{#unless isCatchAll}}
+		if (response.status === {{code}}) {
+			{{#if contents}}
+			{{#each contents}} 
+			if (mimeType === {{{stringLiteral mediaType.mimeType}}}) {
+				{{>frag/apiResponseContent group=../../.. operation=../.. response=..}}
+			}
+			{{/each}}
+			{{else}}
+			{{>frag/apiResponseContent group=../.. operation=.. response=.}}
+			{{/if}}
+		}
+		{{/unless}}
+		{{/each}}
+		{{#if catchAllResponse}}
+		/* Catch-all response */
+		{{#with catchAllResponse}}
 		{{#if contents}}
 		{{#each contents}} 
 		if (mimeType === {{{stringLiteral mediaType.mimeType}}}) {
@@ -183,31 +200,22 @@ export async function {{identifier name}}({{#each parameters}}{{>frag/parameter}
 		{{else}}
 		{{>frag/apiResponseContent group=../.. operation=.. response=.}}
 		{{/if}}
-	}
-	{{/unless}}
-	{{/each}}
-	{{#if catchAllResponse}}
-	/* Catch-all response */
-	{{#with catchAllResponse}}
-	{{#if contents}}
-	{{#each contents}} 
-	if (mimeType === {{{stringLiteral mediaType.mimeType}}}) {
-		{{>frag/apiResponseContent group=../../.. operation=../.. response=..}}
-	}
-	{{/each}}
-	{{else}}
-	{{>frag/apiResponseContent group=../.. operation=.. response=.}}
-	{{/if}}
-	{{/with}}
-	{{else}}
+		{{/with}}
+		{{else}}
 
-	/* Undocumented response */
-	return {
-		status: response.status,
-		contentType: mimeType,
-		response,
+		/* Undocumented response */
+		return {
+			status: response.status,
+			contentType: mimeType,
+			response,
+		}
+		{{/if}}
+	} catch (error) {
+		return {
+			status: 'error',
+			error,
+		}
 	}
-	{{/if}}
 }
 {{/each}}
 

--- a/packages/typescript-fetch-client2/templates/api.hbs
+++ b/packages/typescript-fetch-client2/templates/api.hbs
@@ -180,7 +180,6 @@ export async function {{identifier name}}({{#each parameters}}{{>frag/parameter}
 			{{>frag/apiResponseContent group=../../.. operation=../.. response=..}}
 		}
 		{{/each}}
-		throw response;
 		{{else}}
 		{{>frag/apiResponseContent group=../.. operation=.. response=.}}
 		{{/if}}
@@ -196,13 +195,18 @@ export async function {{identifier name}}({{#each parameters}}{{>frag/parameter}
 		{{>frag/apiResponseContent group=../../.. operation=../.. response=..}}
 	}
 	{{/each}}
-	throw response;
 	{{else}}
 	{{>frag/apiResponseContent group=../.. operation=.. response=.}}
 	{{/if}}
 	{{/with}}
 	{{else}}
-	throw response;
+
+	/* Undocumented response */
+	return {
+		status: response.status,
+		contentType: mimeType,
+		response,
+	}
 	{{/if}}
 }
 {{/each}}

--- a/packages/typescript-fetch-client2/templates/api.hbs
+++ b/packages/typescript-fetch-client2/templates/api.hbs
@@ -2,7 +2,7 @@
 
 import { Configuration, getDefaultConfiguration } from "../configuration";
 import { COLLECTION_FORMATS, encodeURIPathSegment, FetchArgs, RequiredError, dateToString } from "../runtime";
-import { Api } from "../models";
+import { Api, UndocumentedReponse, FetchErrorResponse } from "../models";
 {{#ifeq dateApproach 'blind-date'}}
 import { LocalDateString, LocalTimeString, LocalDateTimeString, OffsetDateTimeString } from 'blind-date';
 {{/ifeq}}

--- a/packages/typescript-fetch-client2/templates/api.hbs
+++ b/packages/typescript-fetch-client2/templates/api.hbs
@@ -203,9 +203,8 @@ export async function {{identifier name}}({{#each parameters}}{{>frag/parameter}
 		{{/with}}
 		{{else}}
 
-		/* Undocumented response */
 		return {
-			status: response.status,
+			status: 'undocumented',
 			contentType: mimeType,
 			response,
 		}

--- a/packages/typescript-fetch-client2/templates/frag/apiResponseTypes.hbs
+++ b/packages/typescript-fetch-client2/templates/frag/apiResponseTypes.hbs
@@ -8,6 +8,8 @@ export type {{className name}}Response =
 	| {{className (concat ../name '_' code)}}Response
 {{/if}}
 {{/each}}
+	| UndocumentedReponse
+	| FetchErrorResponse
 
 {{#each responses}}
 {{#if contents}}

--- a/packages/typescript-fetch-client2/templates/models.hbs
+++ b/packages/typescript-fetch-client2/templates/models.hbs
@@ -7,6 +7,24 @@ import { LocalDateString, LocalTimeString, LocalDateTimeString, OffsetDateTimeSt
 
 type ValuesOf<T> = T[keyof T]
 
+/**
+ * An undocumented response from the API. This could be due to an unexpected status code or content
+ * type.
+ */
+export interface UndocumentedReponse {
+	status: number
+	response: Response
+	contentType?: string
+}
+
+/**
+ * An error that occured while trying to call the API, such as due to network errors.
+ */ 
+export interface FetchErrorResponse {
+	status: 'error'
+	error: unknown
+}
+
 export namespace Api {
 {{>nestedModels}}
 }

--- a/packages/typescript-fetch-client2/templates/models.hbs
+++ b/packages/typescript-fetch-client2/templates/models.hbs
@@ -12,7 +12,7 @@ type ValuesOf<T> = T[keyof T]
  * type.
  */
 export interface UndocumentedReponse {
-	status: number
+	status: 'undocumented'
 	response: Response
 	contentType?: string
 }


### PR DESCRIPTION
Enforces that all errors are handled by the user by including strongly typed `undocumented` and `error` response types. By not mixing thrown errors with normal error responses, this simplifies the code flow in consuming applications.

An example of how this looks in Letterboxd can be seen in: https://github.com/Letterboxd/letterboxd/pull/1360