### PR TITLE
typescript-fetch-client2: re-export named types using `type` keyword

### DIFF
--- a/.changeset/slow-geckos-relate.md
+++ b/.changeset/slow-geckos-relate.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/typescript-fetch-client-generator2": patch
+---
+
+Re-export named types using type keyword.

--- a/packages/typescript-fetch-client2/templates/index.hbs
+++ b/packages/typescript-fetch-client2/templates/index.hbs
@@ -7,8 +7,8 @@ import { withConfiguration as {{identifier name}}ApiWithConfiguration } from './
 
 export * from "./models";
 export * from "./configuration";
-export { RequiredError, UndocumentedResponse, FetchErrorResponse, UnexpectedResponse, isUnexpectedResponse, isDocumentedResponse } from "./runtime";
-export type { FetchAPI, FetchArgs } from "./runtime";
+export { RequiredError, isUnexpectedResponse, isDocumentedResponse } from "./runtime";
+export type { FetchAPI, FetchArgs, UndocumentedResponse, FetchErrorResponse, UnexpectedResponse } from "./runtime";
 
 {{#each groups}}
 export { default as {{className name}}Api } from './api/{{identifier name}}'

--- a/packages/typescript-fetch-client2/templates/runtime.hbs
+++ b/packages/typescript-fetch-client2/templates/runtime.hbs
@@ -60,7 +60,7 @@ export interface FetchErrorResponse {
 export type UnexpectedResponse = UndocumentedResponse | FetchErrorResponse
 
 export function isUnexpectedResponse<T extends object>(response: T | UnexpectedResponse): response is UnexpectedResponse {
-	return "status" in response && (response.status === 'undocumented' || response.status === 'error')
+	return 'status' in response && (response.status === 'undocumented' || response.status === 'error')
 }
 
 export function isDocumentedResponse<T extends object>(response: T | UnexpectedResponse): response is T {


### PR DESCRIPTION
From what I've read we _should_ be using `type` when re-exporting types. From [the Typescript Isolated modules setting](https://www.typescriptlang.org/tsconfig/#isolatedModules):

> While you can use TypeScript to produce JavaScript code from TypeScript code, it’s also common to use other transpilers such as [Babel](https://babeljs.io/) to do this. However, other transpilers only operate on a single file at a time, which means they can’t apply code transforms that depend on understanding the full type system. This restriction also applies to TypeScript’s ts.transpileModule API which is used by some build tools.
>
>  ...
>
> In TypeScript, you can import a type and then subsequently export it:
> ```ts
> import { someType, someFunction } from "someModule";
> 
> someFunction();
> 
> export { someType, someFunction };
> ```
> 
> Because there’s no value for someType, the emitted export will not try to export it (this would be a runtime error in JavaScript):
> ```ts
> export { someFunction };
>```

I suspect—at least in dev mode—esbuild (Vite's bundler) likely uses `ts.transpileModule` which is why this is causing issues.