### PR TITLE
fix: explicitly set the content type of responses

### DIFF
--- a/.changeset/polite-phones-rush.md
+++ b/.changeset/polite-phones-rush.md
@@ -1,5 +1,5 @@
 ---
-"@openapi-generator-plus/java-jaxrs-server-generator": patch
+"@openapi-generator-plus/java-jaxrs-server-generator": minor
 ---
 
 Explicitly set the content type of responses.

--- a/.changeset/polite-phones-rush.md
+++ b/.changeset/polite-phones-rush.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/java-jaxrs-server-generator": patch
+---
+
+Explicitly set the content type of responses.

--- a/packages/java-jaxrs-server/templates/apiImpl.hbs
+++ b/packages/java-jaxrs-server/templates/apiImpl.hbs
@@ -79,6 +79,9 @@ __response
 			{{>frag/beanValidationValidateResponse responseVar='__entity' schema=defaultContent.schema}}
 			{{/if}}
 			__response.entity(__entity);
+			{{#if defaultContent}}
+			__response.type({{{stringLiteral defaultContent.mediaType.mediaType}}});
+			{{/if}}
 			{{/if}}
 			return __response.build();
 			{{/with}}
@@ -95,6 +98,9 @@ __response
 			{{>frag/beanValidationValidateResponse responseVar='__e.getEntity()' schema=defaultContent.schema}}
 			{{/if}}
 			__response.entity(__e.getEntity());
+			{{#if defaultContent}}
+			__response.type({{{stringLiteral defaultContent.mediaType.mediaType}}});
+			{{/if}}
 			{{/if}}
 			return __response.build();
 		{{/unless}}


### PR DESCRIPTION
### Description
Prevent incorrect response `Content-Type` header by explicitly setting the content type when building the response.