### PR TITLE
typescript-fetch-node-client: fix type delimiting in docs

### DIFF
--- a/packages/typescript-fetch-node-client/README.md
+++ b/packages/typescript-fetch-node-client/README.md
@@ -22,10 +22,10 @@ The available config file properties are:
 
 |Property|Type|Description|Default|
 |--------|----|-----------|-------|
-|`constantStyle`|`"allCapsSnake"|"allCaps"|"camelCase"|"pascalCase"`|The style to use for constant naming.|`"pascalCase"`|
+|`constantStyle`|`"allCapsSnake"\|"allCaps"\|"camelCase"\|"pascalCase"`|The style to use for constant naming.|`"pascalCase"`|
 |`enumMemberStyle`|`"preserve"` \| `"constant"`|The style to use for enum member names: `preserve` _attempts_ to match the enum member name to the literal enum value from the spec; `constant` uses the `constantStyle` rules.|`"constant"`|
 |`legacyUnnamespacedModelSupport`|`boolean`|Generate unnamespaced versions of the models.|`false`|
-|`dateApproach`|`"native"|"string"|"blind-date"`|Whether to use `string` for date and time and `Date` for date-time, or just `string`, or whether to use [blind-date](https://npmjs.com/blind-date) for dates and times.|`native`|
+|`dateApproach`|`"native"\|"string"\|"blind-date"`|Whether to use `string` for date and time and `Date` for date-time, or just `string`, or whether to use [blind-date](https://npmjs.com/blind-date) for dates and times.|`native`|
 
 ### TypeScript
 


### PR DESCRIPTION
There was some incorrect escaping of pipe characters. I notice this had been fixed in a couple of locations but hadn't been fixed here.

| | `constantStyle` |
| --- | --- |
| Before | <img width="1037" height="133" alt="image" src="https://github.com/user-attachments/assets/5dac577a-5ecf-4d20-bd23-d66037538da3" /> |
| After | <img width="1037" height="180" alt="image" src="https://github.com/user-attachments/assets/683d3f7d-42de-4e68-8e8c-120e8feb2e82" /> |

| | `dateApproach` |
| --- | --- |
| Before | <img width="1037" height="74" alt="image" src="https://github.com/user-attachments/assets/92d73b70-9940-45bd-b22f-669670b27e84" /> |
| After | <img width="1037" height="256" alt="image" src="https://github.com/user-attachments/assets/8e6a564c-b5b4-4108-a911-405cb2e41d51" /> |



