### PR TITLE
java-jaxrs-server: header generation

### DIFF
--- a/.changeset/clean-nails-kneel.md
+++ b/.changeset/clean-nails-kneel.md
@@ -1,0 +1,6 @@
+---
+"@openapi-generator-plus/java-jaxrs-generator-common": minor
+"@openapi-generator-plus/java-jaxrs-server-generator": minor
+---
+
+Add support for response headers

--- a/.changeset/jolly-chefs-film.md
+++ b/.changeset/jolly-chefs-film.md
@@ -1,0 +1,8 @@
+---
+"@openapi-generator-plus/java-cxf-spring-server-generator": patch
+"@openapi-generator-plus/java-cxf-cdi-server-generator": patch
+"@openapi-generator-plus/java-jaxrs-client-generator": patch
+"@openapi-generator-plus/java-jaxrs-server-generator": patch
+---
+
+Upgrade Lombok to 1.18.46 in generated pom.xml

--- a/.changeset/plenty-streets-sleep.md
+++ b/.changeset/plenty-streets-sleep.md
@@ -1,0 +1,6 @@
+---
+"@openapi-generator-plus/typescript-fetch-node-client-generator2": patch
+"@openapi-generator-plus/typescript-fetch-client-generator2": patch
+---
+
+Fix handling of non-string header schemas

--- a/.changeset/ready-taxes-wear.md
+++ b/.changeset/ready-taxes-wear.md
@@ -1,0 +1,7 @@
+---
+"@openapi-generator-plus/java-jaxrs-server-generator": minor
+---
+
+Remove `ResponseBuilder` parameter from service methods with no return type
+
+We now have support for response headers so there is no longer any reason to have the `ResponseBuilder` parameter (not that it really made sense in the first place except as a workaround for responses the generator didn't support).

--- a/__tests__/specs/response-headers.yml
+++ b/__tests__/specs/response-headers.yml
@@ -1,0 +1,92 @@
+openapi: '3.0.3'
+info:
+  title: Response Headers Test
+  version: '1.0'
+paths:
+  /users/{id}:
+    get:
+      operationId: getUser
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: OK
+          headers:
+            X-RateLimit-Limit:
+              description: The number of allowed requests in the current period
+              schema:
+                type: integer
+            X-RateLimit-Remaining:
+              description: The number of remaining requests in the current period
+              schema:
+                type: integer
+            X-Request-Id:
+              description: Request ID for tracking
+              required: true
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+        201:
+          description: Created
+          headers:
+            X-RateLimit-Limit:
+              description: The number of allowed requests in the current period
+              schema:
+                type: integer
+            X-RateLimit-Remaining:
+              description: The number of remaining requests in the current period
+              schema:
+                type: integer
+            X-Request-Id:
+              description: Request ID for tracking
+              required: true
+              schema:
+                type: string
+        404:
+          description: Not Found
+          headers:
+            X-Error-Code:
+              description: Error code
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+  /items:
+    get:
+      operationId: listItems
+      responses:
+        200:
+          description: OK
+          headers:
+            X-Total-Count:
+              description: Total number of items
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string

--- a/packages/java-cxf-cdi-server/templates/pom.hbs
+++ b/packages/java-cxf-cdi-server/templates/pom.hbs
@@ -44,7 +44,7 @@
 		{{/if}}
 		{{/if}}
 		{{#if useLombok}}
-		<lombok.version>{{lookup maven.versions 'lombok' '1.18.42'}}</lombok.version>
+		<lombok.version>{{lookup maven.versions 'lombok' '1.18.46'}}</lombok.version>
 		{{/if}}
 		{{>hooks/pomProperties}}
 	</properties>

--- a/packages/java-cxf-spring-server/templates/pom.hbs
+++ b/packages/java-cxf-spring-server/templates/pom.hbs
@@ -40,7 +40,7 @@
 		{{/ifeq}}
 		{{/if}}
 		{{#if useLombok}}
-		<lombok.version>{{lookup maven.versions 'lombok' '1.18.42'}}</lombok.version>
+		<lombok.version>{{lookup maven.versions 'lombok' '1.18.46'}}</lombok.version>
 		{{/if}}
 		{{>hooks/pomProperties}}
 	</properties>

--- a/packages/java-jaxrs-client/templates/pom.hbs
+++ b/packages/java-jaxrs-client/templates/pom.hbs
@@ -28,7 +28,7 @@
 		{{/if}}
 		{{/if}}
 		{{#if useLombok}}
-		<lombok.version>{{lookup maven.versions 'lombok' '1.18.42'}}</lombok.version>
+		<lombok.version>{{lookup maven.versions 'lombok' '1.18.46'}}</lombok.version>
 		{{/if}}
 		{{>hooks/pomProperties}}
 	</properties>

--- a/packages/java-jaxrs-common/src/index.ts
+++ b/packages/java-jaxrs-common/src/index.ts
@@ -1,4 +1,4 @@
-import { CodegenSchemaType, CodegenConfig, CodegenGeneratorContext, CodegenDocument, CodegenGenerator, isCodegenObjectSchema, isCodegenEnumSchema, CodegenNativeType, CodegenProperty, CodegenAllOfStrategy, CodegenAnyOfStrategy, CodegenOneOfStrategy, CodegenLogLevel, isCodegenInterfaceSchema, isCodegenWrapperSchema, CodegenSchema, CodegenSchemaPurpose, CodegenEncodingStyle } from '@openapi-generator-plus/types'
+import { CodegenSchemaType, CodegenConfig, CodegenGeneratorContext, CodegenDocument, CodegenGenerator, isCodegenObjectSchema, isCodegenEnumSchema, CodegenNativeType, CodegenProperty, CodegenAllOfStrategy, CodegenAnyOfStrategy, CodegenOneOfStrategy, CodegenLogLevel, isCodegenInterfaceSchema, isCodegenWrapperSchema, CodegenSchema, CodegenSchemaPurpose, CodegenEncodingStyle, CodegenParameter, CodegenHeader } from '@openapi-generator-plus/types'
 import { CodegenOptionsJava } from './types'
 import path from 'path'
 import Handlebars from 'handlebars'
@@ -600,7 +600,7 @@ export default function createGenerator(config: CodegenConfig, context: JavaGene
 
 			registerStandardHelpers(hbs, context)
 
-			hbs.registerHelper('getter', function(property: CodegenProperty) {
+			hbs.registerHelper('getter', function(property: CodegenProperty | CodegenParameter | CodegenHeader) {
 				let propertyName = context.generator().toIdentifier(property.name)
 				if (generatorOptions.useLombok) {
 					propertyName = lombokPropertyName(property, propertyName)
@@ -611,7 +611,7 @@ export default function createGenerator(config: CodegenConfig, context: JavaGene
 					return `get${capitalize(propertyName)}`
 				}
 			})
-			hbs.registerHelper('setter', function(property: CodegenProperty) {
+			hbs.registerHelper('setter', function(property: CodegenProperty | CodegenParameter | CodegenHeader) {
 				let propertyName = context.generator().toIdentifier(property.name)
 				if (generatorOptions.useLombok) {
 					propertyName = lombokPropertyName(property, propertyName)
@@ -778,7 +778,7 @@ function isNativeArrayType(nativeType: CodegenNativeType): boolean {
 	return nativeType.nativeType.endsWith('[]')
 }
 
-function isPrimitiveBool(property: CodegenProperty): boolean {
+function isPrimitiveBool(property: CodegenProperty | CodegenParameter | CodegenHeader): boolean {
 	return property.schema.schemaType === CodegenSchemaType.BOOLEAN && property.required && !property.nullable
 }
 
@@ -788,7 +788,7 @@ function isPrimitiveBool(property: CodegenProperty): boolean {
  * instead of `@Getter isIsAdmin()`, `@Setter setIsAdmin()`
  * See https://projectlombok.org/features/GetterSetter
  */
-function lombokPropertyName(property: CodegenProperty, propertyName: string) {
+function lombokPropertyName(property: CodegenProperty | CodegenParameter | CodegenHeader, propertyName: string) {
 	if (isPrimitiveBool(property)) {
 		return propertyName.replace(/^is(?=[A-Z])/, '')
 	} else {

--- a/packages/java-jaxrs-server/src/__tests__/response-headers.spec.ts
+++ b/packages/java-jaxrs-server/src/__tests__/response-headers.spec.ts
@@ -1,0 +1,111 @@
+import { createCodegenResult, idx } from '@openapi-generator-plus/testing'
+import path from 'path'
+import createGenerator from '..'
+import { MyResponse } from '../internal-types'
+
+test('response with headers generates wrapper class info', async() => {
+	const result = await createCodegenResult(path.resolve(__dirname, 'response-headers.yml'), {}, createGenerator)
+	const { doc } = result
+
+	expect(doc.groups.length).toBeGreaterThan(0)
+	const group1 = doc.groups[0]
+	expect(group1.operations.length).toBeGreaterThan(0)
+	
+	const getUserOp = group1.operations.find(op => {
+		const defaultResponse = op.defaultResponse
+		return defaultResponse && (defaultResponse as MyResponse).wrapper
+	})
+	expect(getUserOp).toBeDefined()
+	
+	if (!getUserOp) return
+
+	const defaultResponse = getUserOp.defaultResponse
+	expect(defaultResponse).toBeDefined()
+	if (!defaultResponse) return
+
+	expect(defaultResponse.defaultContent).toBeDefined()
+	if (!defaultResponse.defaultContent) return
+
+	const wrapperName = (defaultResponse as MyResponse).wrapper?.name
+	expect(wrapperName).toBeDefined()
+	expect(typeof wrapperName).toBe('string')
+	expect(wrapperName).toContain('ListItemsDefaultResponse')
+	
+	expect(defaultResponse.defaultContent.nativeType?.nativeType).toBeDefined()
+	expect(defaultResponse.defaultContent.nativeType?.nativeType).toContain('ListItemsDefaultResponse')
+	
+	const wrapperHeaders = (defaultResponse as MyResponse).wrapper?.headers
+	expect(wrapperHeaders).toBeDefined()
+	expect(Array.isArray(wrapperHeaders)).toBe(true)
+	expect(wrapperHeaders!.length).toBeGreaterThan(0)
+	
+	const wrapperBodyType = (defaultResponse as MyResponse).wrapper?.bodyNativeType
+	expect(wrapperBodyType).toBeDefined()
+})
+
+test('operations have multiple responses for header testing', async() => {
+	const result = await createCodegenResult(path.resolve(__dirname, 'response-headers.yml'), {}, createGenerator)
+	const { doc } = result
+
+	expect(doc.groups.length).toBeGreaterThan(0)
+	const group1 = doc.groups[0]
+	expect(group1.operations.length).toBeGreaterThan(0)
+	
+	let hasResponses = false
+	for (const op of group1.operations) {
+		if (op.responses) {
+			const allResponses = idx.allValues(op.responses)
+			if (allResponses.length > 0) {
+				hasResponses = true
+				break
+			}
+		}
+	}
+	expect(hasResponses).toBe(true)
+})
+
+test('response wrapper class info is set for generation', async() => {
+	const result = await createCodegenResult(path.resolve(__dirname, 'response-headers.yml'), {}, createGenerator)
+	const { doc } = result
+
+	const group1 = doc.groups[0]
+	const opWithWrapper = group1.operations.find(op => {
+		const defaultResponse = op.defaultResponse
+		return defaultResponse && (defaultResponse as MyResponse).wrapper?.name
+	})
+	expect(opWithWrapper).toBeDefined()
+	
+	if (!opWithWrapper) return
+	
+	const defaultResponse = opWithWrapper.defaultResponse
+	expect(defaultResponse).toBeDefined()
+	if (!defaultResponse || !defaultResponse.defaultContent) return
+	
+	const wrapperName = (defaultResponse as MyResponse).wrapper?.name
+	expect(wrapperName).toBeDefined()
+	expect(typeof wrapperName).toBe('string')
+	expect((defaultResponse as MyResponse).wrapper?.headers).toBeDefined()
+	expect((defaultResponse as MyResponse).wrapper?.bodyNativeType).toBeDefined()
+})
+
+test('response with headers generates wrapper for listItems', async() => {
+	const result = await createCodegenResult(path.resolve(__dirname, 'response-headers.yml'), {}, createGenerator)
+	const { doc } = result
+
+	const group1 = doc.groups[0]
+	const listItemsOp = group1.operations.find(op => op.name === 'listItems')
+	expect(listItemsOp).toBeDefined()
+	
+	if (!listItemsOp) return
+
+	const defaultResponse = listItemsOp.defaultResponse
+	expect(defaultResponse).toBeDefined()
+	if (!defaultResponse) return
+
+	expect(defaultResponse.defaultContent).toBeDefined()
+	if (!defaultResponse.defaultContent) return
+
+	const wrapperName = (defaultResponse as MyResponse).wrapper?.name
+	expect(wrapperName).toBe('ListItemsDefaultResponse')
+})
+

--- a/packages/java-jaxrs-server/src/__tests__/response-headers.spec.ts
+++ b/packages/java-jaxrs-server/src/__tests__/response-headers.spec.ts
@@ -13,7 +13,7 @@ test('response with headers generates wrapper class info', async() => {
 	
 	const getUserOp = group1.operations.find(op => {
 		const defaultResponse = op.defaultResponse
-		return defaultResponse && (defaultResponse as MyResponse).wrapper
+		return defaultResponse && (defaultResponse as MyResponse).__wrapper
 	})
 	expect(getUserOp).toBeDefined()
 	
@@ -26,7 +26,7 @@ test('response with headers generates wrapper class info', async() => {
 	expect(defaultResponse.defaultContent).toBeDefined()
 	if (!defaultResponse.defaultContent) return
 
-	const wrapperName = (defaultResponse as MyResponse).wrapper?.name
+	const wrapperName = (defaultResponse as MyResponse).__wrapper?.name
 	expect(wrapperName).toBeDefined()
 	expect(typeof wrapperName).toBe('string')
 	expect(wrapperName).toContain('ListItemsDefaultResponse')
@@ -34,12 +34,12 @@ test('response with headers generates wrapper class info', async() => {
 	expect(defaultResponse.defaultContent.nativeType?.nativeType).toBeDefined()
 	expect(defaultResponse.defaultContent.nativeType?.nativeType).toContain('ListItemsDefaultResponse')
 	
-	const wrapperHeaders = (defaultResponse as MyResponse).wrapper?.headers
+	const wrapperHeaders = (defaultResponse as MyResponse).__wrapper?.headers
 	expect(wrapperHeaders).toBeDefined()
 	expect(Array.isArray(wrapperHeaders)).toBe(true)
 	expect(wrapperHeaders!.length).toBeGreaterThan(0)
 	
-	const wrapperBodyType = (defaultResponse as MyResponse).wrapper?.bodyNativeType
+	const wrapperBodyType = (defaultResponse as MyResponse).__wrapper?.bodyNativeType
 	expect(wrapperBodyType).toBeDefined()
 })
 
@@ -71,7 +71,7 @@ test('response wrapper class info is set for generation', async() => {
 	const group1 = doc.groups[0]
 	const opWithWrapper = group1.operations.find(op => {
 		const defaultResponse = op.defaultResponse
-		return defaultResponse && (defaultResponse as MyResponse).wrapper?.name
+		return defaultResponse && (defaultResponse as MyResponse).__wrapper?.name
 	})
 	expect(opWithWrapper).toBeDefined()
 	
@@ -81,11 +81,11 @@ test('response wrapper class info is set for generation', async() => {
 	expect(defaultResponse).toBeDefined()
 	if (!defaultResponse || !defaultResponse.defaultContent) return
 	
-	const wrapperName = (defaultResponse as MyResponse).wrapper?.name
+	const wrapperName = (defaultResponse as MyResponse).__wrapper?.name
 	expect(wrapperName).toBeDefined()
 	expect(typeof wrapperName).toBe('string')
-	expect((defaultResponse as MyResponse).wrapper?.headers).toBeDefined()
-	expect((defaultResponse as MyResponse).wrapper?.bodyNativeType).toBeDefined()
+	expect((defaultResponse as MyResponse).__wrapper?.headers).toBeDefined()
+	expect((defaultResponse as MyResponse).__wrapper?.bodyNativeType).toBeDefined()
 })
 
 test('response with headers generates wrapper for listItems', async() => {
@@ -105,7 +105,7 @@ test('response with headers generates wrapper for listItems', async() => {
 	expect(defaultResponse.defaultContent).toBeDefined()
 	if (!defaultResponse.defaultContent) return
 
-	const wrapperName = (defaultResponse as MyResponse).wrapper?.name
+	const wrapperName = (defaultResponse as MyResponse).__wrapper?.name
 	expect(wrapperName).toBe('ListItemsDefaultResponse')
 })
 

--- a/packages/java-jaxrs-server/src/__tests__/response-headers.yml
+++ b/packages/java-jaxrs-server/src/__tests__/response-headers.yml
@@ -26,7 +26,6 @@ paths:
                 type: integer
             X-Request-Id:
               description: Request ID for tracking
-              required: true
               schema:
                 type: string
           content:
@@ -38,24 +37,6 @@ paths:
                     type: string
                   name:
                     type: string
-        201:
-          description: Created
-          headers:
-            X-RateLimit-Limit:
-              description: The number of allowed requests in the current period
-              schema:
-                type: integer
-            X-RateLimit-Remaining:
-              description: The number of remaining requests in the current period
-              schema:
-                type: integer
-            X-Request-Id:
-              description: Request ID for tracking
-              required: true
-              schema:
-                type: string
-        204:
-          description: Nothing
         404:
           description: Not Found
           headers:
@@ -92,3 +73,9 @@ paths:
                       type: string
                     name:
                       type: string
+
+
+
+
+
+

--- a/packages/java-jaxrs-server/src/index.ts
+++ b/packages/java-jaxrs-server/src/index.ts
@@ -1,9 +1,10 @@
-import { CodegenConfig, CodegenGeneratorConstructor, CodegenGeneratorType } from '@openapi-generator-plus/types'
+import { CodegenConfig, CodegenGeneratorConstructor, CodegenGeneratorType, CodegenHeader, CodegenNativeType, CodegenResponse } from '@openapi-generator-plus/types'
 import path from 'path'
 import { apiBasePath, configString, nullableConfigString } from '@openapi-generator-plus/generator-common'
 import { emit, loadTemplates } from '@openapi-generator-plus/handlebars-templates'
 import javaGenerator, { options as javaGeneratorOptions, packageToPath, JavaGeneratorContext } from '@openapi-generator-plus/java-jaxrs-generator-common'
 import { CodegenOptionsJavaServer } from './types'
+import { MyResponse } from './internal-types'
 export { packageToPath } from '@openapi-generator-plus/java-jaxrs-generator-common'
 export { CodegenOptionsJavaServer } from './types'
 
@@ -163,6 +164,44 @@ export const createGenerator: CodegenGeneratorConstructor<JavaGeneratorContext> 
 			}
 		},
 		generatorType: () => CodegenGeneratorType.SERVER,
+		postProcessDocument: (doc, helper) => {
+			if (base.postProcessDocument) {
+				base.postProcessDocument(doc, helper)
+			}
+
+			/* Create response wrappers in order to support response headers */
+			for (const group of doc.groups) {
+				for (const operation of group.operations) {
+					if (!operation.responses) {
+						continue
+					}
+					
+					for (const response of context.utils.values(operation.responses) as Iterable<MyResponse>) {
+						if (response.headers && response.isDefault) {
+							const headers = Array.from(context.utils.values(response.headers))
+							if (headers.length > 0) {
+								const wrapperName = `${context.generator().toClassName(operation.uniqueName)}DefaultResponse`
+								const wrapperNativeType = new context.NativeType(`${generatorOptions.apiServicePackage}.${context.generator().toClassName(group.name)}ApiService.${wrapperName}`)
+								const bodyNativeType = response.defaultContent?.nativeType || null
+								
+								response.wrapper = {
+									name: wrapperName,
+									headers,
+									bodyNativeType: bodyNativeType,
+									nativeType: wrapperNativeType,
+								}
+								if (response.defaultContent) {
+									response.defaultContent.nativeType = wrapperNativeType
+								}
+								operation.returnNativeType = wrapperNativeType
+							}
+						} else {
+							response.wrapper = null
+						}
+					}
+				}
+			}
+		},
 	}
 }
 

--- a/packages/java-jaxrs-server/src/index.ts
+++ b/packages/java-jaxrs-server/src/index.ts
@@ -1,4 +1,4 @@
-import { CodegenConfig, CodegenGeneratorConstructor, CodegenGeneratorType, CodegenHeader, CodegenNativeType, CodegenResponse } from '@openapi-generator-plus/types'
+import { CodegenConfig, CodegenGeneratorConstructor, CodegenGeneratorType } from '@openapi-generator-plus/types'
 import path from 'path'
 import { apiBasePath, configString, nullableConfigString } from '@openapi-generator-plus/generator-common'
 import { emit, loadTemplates } from '@openapi-generator-plus/handlebars-templates'
@@ -184,7 +184,7 @@ export const createGenerator: CodegenGeneratorConstructor<JavaGeneratorContext> 
 								const wrapperNativeType = new context.NativeType(`${generatorOptions.apiServicePackage}.${context.generator().toClassName(group.name)}ApiService.${wrapperName}`)
 								const bodyNativeType = response.defaultContent?.nativeType || null
 								
-								response.wrapper = {
+								response.__wrapper = {
 									name: wrapperName,
 									headers,
 									bodyNativeType: bodyNativeType,
@@ -196,7 +196,7 @@ export const createGenerator: CodegenGeneratorConstructor<JavaGeneratorContext> 
 								operation.returnNativeType = wrapperNativeType
 							}
 						} else {
-							response.wrapper = null
+							response.__wrapper = null
 						}
 					}
 				}

--- a/packages/java-jaxrs-server/src/internal-types.ts
+++ b/packages/java-jaxrs-server/src/internal-types.ts
@@ -1,0 +1,12 @@
+import { CodegenHeader, CodegenNativeType, CodegenResponse } from '@openapi-generator-plus/types'
+
+export interface MyResponse extends CodegenResponse {
+	wrapper: MyDefaultResponseWrapper | null
+}
+
+export interface MyDefaultResponseWrapper {
+	name: string
+	headers: CodegenHeader[] | null
+	bodyNativeType: CodegenNativeType | null
+	nativeType: CodegenNativeType
+}

--- a/packages/java-jaxrs-server/src/internal-types.ts
+++ b/packages/java-jaxrs-server/src/internal-types.ts
@@ -1,7 +1,7 @@
 import { CodegenHeader, CodegenNativeType, CodegenResponse } from '@openapi-generator-plus/types'
 
 export interface MyResponse extends CodegenResponse {
-	wrapper: MyDefaultResponseWrapper | null
+	__wrapper: MyDefaultResponseWrapper | null
 }
 
 export interface MyDefaultResponseWrapper {

--- a/packages/java-jaxrs-server/templates/apiImpl.hbs
+++ b/packages/java-jaxrs-server/templates/apiImpl.hbs
@@ -15,9 +15,6 @@ public class {{className name}}ApiImpl implements {{apiPackage}}.{{className nam
 {{>frag/operationVars op=. jaxrs=false service=false}}
 {{#join '_arguments' ', '}}
 {{{_arguments}}}
-{{#unless defaultResponse.defaultContent.nativeType}}
-__response
-{{/unless}}
 {{/join}}
 	{{>frag/operationDocumentation}}
 	@java.lang.Override

--- a/packages/java-jaxrs-server/templates/apiImpl.hbs
+++ b/packages/java-jaxrs-server/templates/apiImpl.hbs
@@ -19,6 +19,7 @@ public class {{className name}}ApiImpl implements {{apiPackage}}.{{className nam
 __response
 {{/unless}}
 {{/join}}
+	{{>frag/operationDocumentation}}
 	@java.lang.Override
 	{{#if deprecated}}
 	@java.lang.SuppressWarnings("deprecation")
@@ -77,15 +78,23 @@ __response
 			{{>frag/beanValidationValidateParams}}
 			{{/if}}
 			{{#with defaultResponse}}
+			{{#if wrapper}}
+			{{{wrapper.nativeType}}} __wrapper = this.delegate.{{identifier ../name}}({{{../_arguments}}});
+			{{#if wrapper.bodyNativeType}}
+			{{{wrapper.bodyNativeType}}} __entity = __wrapper.getBody();
+			{{/if}}
+			{{#each wrapper.headers}}
+			__addHeader(__response, {{{stringLiteral serializedName}}}, __wrapper.{{getter .}}());
+			{{/each}}
+			{{else}}
 			{{#if defaultContent.nativeType}}{{{defaultContent.nativeType}}} __entity = {{/if}}this.delegate.{{identifier ../name}}({{{../_arguments}}});
+			{{/if}}
 			{{#if defaultContent.nativeType}}
 			{{#if @root.useBeanValidation}}
 			{{>frag/beanValidationValidateResponse responseVar='__entity' schema=defaultContent.schema}}
 			{{/if}}
 			__response.entity(__entity);
-			{{#if defaultContent}}
 			__response.type({{{stringLiteral defaultContent.mediaType.mediaType}}});
-			{{/if}}
 			{{/if}}
 			return __response.build();
 			{{/with}}
@@ -97,6 +106,9 @@ __response
 			{{else}}
 			__response.status(__e.getResponseCode());
 			{{/unless}}
+			{{#each headers}}
+			__addHeader(__response, {{{stringLiteral serializedName}}}, __e.{{getter .}}());
+			{{/each}}
 			{{#if defaultContent.nativeType}}
 			{{#if @root.useBeanValidation}}
 			{{>frag/beanValidationValidateResponse responseVar='__e.getEntity()' schema=defaultContent.schema}}
@@ -115,4 +127,12 @@ __response
 	}
 
 {{/each}}
+	private void __addHeader({{javax}}.ws.rs.core.Response.ResponseBuilder response, java.lang.String name, java.lang.Object value) {
+		{{!-- Remove existing headers, such as the default Cache-Control header we add. --}}
+		response.header(name, null);
+		if (value != null) {
+			response.header(name, value);
+		}
+	}
+
 }

--- a/packages/java-jaxrs-server/templates/apiImpl.hbs
+++ b/packages/java-jaxrs-server/templates/apiImpl.hbs
@@ -75,12 +75,12 @@ public class {{className name}}ApiImpl implements {{apiPackage}}.{{className nam
 			{{>frag/beanValidationValidateParams}}
 			{{/if}}
 			{{#with defaultResponse}}
-			{{#if wrapper}}
-			{{{wrapper.nativeType}}} __wrapper = this.delegate.{{identifier ../name}}({{{../_arguments}}});
-			{{#if wrapper.bodyNativeType}}
-			{{{wrapper.bodyNativeType}}} __entity = __wrapper.getBody();
+			{{#if __wrapper}}
+			{{{__wrapper.nativeType}}} __wrapper = this.delegate.{{identifier ../name}}({{{../_arguments}}});
+			{{#if __wrapper.bodyNativeType}}
+			{{{__wrapper.bodyNativeType}}} __entity = __wrapper.getBody();
 			{{/if}}
-			{{#each wrapper.headers}}
+			{{#each __wrapper.headers}}
 			__addHeader(__response, {{{stringLiteral serializedName}}}, __wrapper.{{getter .}}());
 			{{/each}}
 			{{else}}

--- a/packages/java-jaxrs-server/templates/apiImpl.hbs
+++ b/packages/java-jaxrs-server/templates/apiImpl.hbs
@@ -81,7 +81,7 @@ public class {{className name}}ApiImpl implements {{apiPackage}}.{{className nam
 			{{{__wrapper.bodyNativeType}}} __entity = __wrapper.getBody();
 			{{/if}}
 			{{#each __wrapper.headers}}
-			__addHeader(__response, {{{stringLiteral serializedName}}}, __wrapper.{{getter .}}());
+			__response.header({{{stringLiteral serializedName}}}, null).header({{{stringLiteral serializedName}}}, __wrapper.{{getter .}}());
 			{{/each}}
 			{{else}}
 			{{#if defaultContent.nativeType}}{{{defaultContent.nativeType}}} __entity = {{/if}}this.delegate.{{identifier ../name}}({{{../_arguments}}});
@@ -104,7 +104,7 @@ public class {{className name}}ApiImpl implements {{apiPackage}}.{{className nam
 			__response.status(__e.getResponseCode());
 			{{/unless}}
 			{{#each headers}}
-			__addHeader(__response, {{{stringLiteral serializedName}}}, __e.{{getter .}}());
+			__response.header({{{stringLiteral serializedName}}}, null).header({{{stringLiteral serializedName}}}, __e.{{getter .}}());
 			{{/each}}
 			{{#if defaultContent.nativeType}}
 			{{#if @root.useBeanValidation}}
@@ -124,12 +124,5 @@ public class {{className name}}ApiImpl implements {{apiPackage}}.{{className nam
 	}
 
 {{/each}}
-	private void __addHeader({{javax}}.ws.rs.core.Response.ResponseBuilder response, java.lang.String name, java.lang.Object value) {
-		{{!-- Remove existing headers, such as the default Cache-Control header we add. --}}
-		response.header(name, null);
-		if (value != null) {
-			response.header(name, value);
-		}
-	}
 
 }

--- a/packages/java-jaxrs-server/templates/apiService.hbs
+++ b/packages/java-jaxrs-server/templates/apiService.hbs
@@ -9,8 +9,11 @@ public interface {{className name}}ApiService {
 	{{>frag/operationDocumentation}}
 	{{#if returnNativeType}}{{{returnNativeType}}}{{else}}void{{/if}} {{identifier name}}({{{_parameters}}}){{#each (nonDefaultResponses)}}{{#if @first}} throws{{else}},{{/if}} {{{className (concat ../name '_' code)}}}Exception{{/each}};
 {{/each}}
-	
+
 	{{#each operations}}
+	{{#if defaultResponse.wrapper}}
+	{{>frag/responseWrapper defaultResponse.wrapper}}
+	{{/if}}
 	{{#each (nonDefaultResponses)}}
 	/**
 	{{#if description}}
@@ -22,52 +25,93 @@ public interface {{className name}}ApiService {
 	 * <p>Sends a response with a {{code}} status.</p>
 	{{/if}}
 	 */
+	{{#if @root.useLombok}}
+	@lombok.Getter
+	@lombok.Setter
+	{{/if}}
 	class {{{className (concat ../name '_' code)}}}Exception extends Exception {
 
 		private static final long serialVersionUID = 1L;
 
-{{#set '_parameters'}}
-{{/set}}
 		{{#if isCatchAll}}
 		private int responseCode;
-{{#set '_parameters'}}
-{{{_parameters}}}
-int responseCode
-{{/set}}
-
 		{{/if}}
 		{{#if defaultContent.nativeType}}
 		private {{{defaultContent.nativeType}}} entity;
-{{#set '_parameters'}}
-{{{_parameters}}}
+		{{/if}}
+		{{#each headers}}
+		private {{{nativeType}}} {{identifier name}};
+		{{/each}}
+{{#join '_parameters' ', '}}
+{{#if isCatchAll}}
+int responseCode
+{{/if}}
+{{#if defaultContent.nativeType}}
 {{{defaultContent.nativeType}}} entity
+{{/if}}
+{{#each headers}}
+{{#if required}}
+{{{nativeType}}} {{identifier name}}
+{{/if}}
+{{/each}}
+{{/join}}
+{{#set '__responseExceptionClassName'}}
+{{{className (concat ../name '_' code)}}}Exception
 {{/set}}
 
-		{{/if}}
-{{#join '_parameters' ', '}}
-{{{_parameters}}}
-{{/join}}
-		public {{{className (concat ../name '_' code)}}}Exception({{{_parameters}}}) {
+		public {{{__responseExceptionClassName}}}({{{_parameters}}}) {
 			{{#if isCatchAll}}
 			this.responseCode = responseCode;
 			{{/if}}
 			{{#if defaultContent.nativeType}}
 			this.entity = entity;
 			{{/if}}
+			{{#each headers}}
+			{{#if required}}
+			this.{{identifier name}} = {{identifier name}};
+			{{/if}}
+			{{/each}}
 		}
 
 		{{#if isCatchAll}}
+		{{#unless @root.useLombok}}
 		public int getResponseCode() {
 			return this.responseCode;
 		}
 
+		{{/unless}}
+		public {{{__responseExceptionClassName}}} responseCode(int responseCode) {
+			this.responseCode = responseCode;
+			return this;
+		}
+
 		{{/if}}
 		{{#if defaultContent.nativeType}}
+		{{#unless @root.useLombok}}
 		public {{{defaultContent.nativeType}}} getEntity() {
 			return this.entity;
 		}
 
+		{{/unless}}
+		public {{{__responseExceptionClassName}}} entity({{{defaultContent.nativeType}}} entity) {
+			this.entity = entity;
+			return this;
+		}
+
 		{{/if}}
+		{{#each headers}}
+		{{#unless @root.useLombok}}
+		public {{{nativeType}}} {{getter .}}() {
+			return this.{{identifier name}};
+		}
+
+		{{/unless}}
+		public {{{../__responseExceptionClassName}}} {{identifier name}}({{{nativeType}}} {{identifier name}}) {
+			this.{{identifier name}} = {{identifier name}};
+			return this;
+		}
+
+		{{/each}}
 		{{>hooks/apiServiceException operation=..}}
 	}
 

--- a/packages/java-jaxrs-server/templates/apiService.hbs
+++ b/packages/java-jaxrs-server/templates/apiService.hbs
@@ -11,8 +11,8 @@ public interface {{className name}}ApiService {
 {{/each}}
 
 	{{#each operations}}
-	{{#if defaultResponse.wrapper}}
-	{{>frag/responseWrapper defaultResponse.wrapper}}
+	{{#if defaultResponse.__wrapper}}
+	{{>frag/responseWrapper defaultResponse.__wrapper}}
 	{{/if}}
 	{{#each (nonDefaultResponses)}}
 	/**

--- a/packages/java-jaxrs-server/templates/apiServiceImpl.hbs
+++ b/packages/java-jaxrs-server/templates/apiServiceImpl.hbs
@@ -10,7 +10,8 @@ public class {{className name}}ApiServiceImpl implements {{@root/apiServicePacka
 	public {{#if returnNativeType}}{{{returnNativeType}}}{{else}}void{{/if}} {{identifier name}}({{{_parameters}}}){{#each (nonDefaultResponses)}}{{#if @first}} throws{{else}},{{/if}} {{{className (concat ../name '_' code)}}}Exception{{/each}} {
 		// TODO
 {{#if returnNativeType}}
-{{#with defaultResponse.contents.[0]}}
+{{#if defaultResponse.defaultContent}}
+{{#with defaultResponse.defaultContent}}
 {{#ifeg 'java'}}
 		return {{{examples.java.valueLiteral}}};
 {{else ifeg 'default'}}
@@ -21,6 +22,9 @@ public class {{className name}}ApiServiceImpl implements {{@root/apiServicePacka
 		throw new UnsupportedOperationException();
 {{/ifeg}}
 {{/with}}
+{{else}}
+		throw new UnsupportedOperationException();
+{{/if}}
 {{/if}}
 	}
 	

--- a/packages/java-jaxrs-server/templates/frag/beanValidationValidateResponse.hbs
+++ b/packages/java-jaxrs-server/templates/frag/beanValidationValidateResponse.hbs
@@ -4,7 +4,7 @@ Validate the response object
 --}}
 {{#if schema.nullable}}
 if ({{{responseVar}}} != null) {
-	java.util.Set<{{javax}}.validation.ConstraintViolation<{{#if wrapper.bodyNativeType}}{{{wrapper.bodyNativeType}}}{{else}}{{{defaultContent.nativeType.componentType}}}{{/if}}>> __validations = this.validatorFactory.getValidator().validate({{{responseVar}}}, {{{@root.validationPackage}}}.Response.class);
+	java.util.Set<{{javax}}.validation.ConstraintViolation<{{#if __wrapper.bodyNativeType}}{{{__wrapper.bodyNativeType}}}{{else}}{{{defaultContent.nativeType.componentType}}}{{/if}}>> __validations = this.validatorFactory.getValidator().validate({{{responseVar}}}, {{{@root.validationPackage}}}.Response.class);
 	if (!__validations.isEmpty()) {
 		{{>hooks/beanValidationResponseViolation responseBuilderVar='__response' violationsVar='__validations' operation=.}}
 	}
@@ -12,7 +12,7 @@ if ({{{responseVar}}} != null) {
 	{{>hooks/beanValidationResponseMissing responseBuilderVar='__response' operation=.}}
 }
 {{else}}
-java.util.Set<{{javax}}.validation.ConstraintViolation<{{#if wrapper.bodyNativeType}}{{{wrapper.bodyNativeType}}}{{else}}{{{defaultContent.nativeType.componentType}}}{{/if}}>> __validations = this.validatorFactory.getValidator().validate({{{responseVar}}}, {{{@root.validationPackage}}}.Response.class);
+java.util.Set<{{javax}}.validation.ConstraintViolation<{{#if __wrapper.bodyNativeType}}{{{__wrapper.bodyNativeType}}}{{else}}{{{defaultContent.nativeType.componentType}}}{{/if}}>> __validations = this.validatorFactory.getValidator().validate({{{responseVar}}}, {{{@root.validationPackage}}}.Response.class);
 if (!__validations.isEmpty()) {
 	{{>hooks/beanValidationResponseViolation responseBuilderVar='__response' violationsVar='__validations' operation=.}}
 }

--- a/packages/java-jaxrs-server/templates/frag/beanValidationValidateResponse.hbs
+++ b/packages/java-jaxrs-server/templates/frag/beanValidationValidateResponse.hbs
@@ -4,7 +4,7 @@ Validate the response object
 --}}
 {{#if schema.nullable}}
 if ({{{responseVar}}} != null) {
-	java.util.Set<{{javax}}.validation.ConstraintViolation<{{{defaultContent.nativeType.componentType}}}>> __validations = this.validatorFactory.getValidator().validate({{{responseVar}}}, {{{@root.validationPackage}}}.Response.class);
+	java.util.Set<{{javax}}.validation.ConstraintViolation<{{#if wrapper.bodyNativeType}}{{{wrapper.bodyNativeType}}}{{else}}{{{defaultContent.nativeType.componentType}}}{{/if}}>> __validations = this.validatorFactory.getValidator().validate({{{responseVar}}}, {{{@root.validationPackage}}}.Response.class);
 	if (!__validations.isEmpty()) {
 		{{>hooks/beanValidationResponseViolation responseBuilderVar='__response' violationsVar='__validations' operation=.}}
 	}
@@ -12,7 +12,7 @@ if ({{{responseVar}}} != null) {
 	{{>hooks/beanValidationResponseMissing responseBuilderVar='__response' operation=.}}
 }
 {{else}}
-java.util.Set<{{javax}}.validation.ConstraintViolation<{{{defaultContent.nativeType.componentType}}}>> __validations = this.validatorFactory.getValidator().validate({{{responseVar}}}, {{{@root.validationPackage}}}.Response.class);
+java.util.Set<{{javax}}.validation.ConstraintViolation<{{#if wrapper.bodyNativeType}}{{{wrapper.bodyNativeType}}}{{else}}{{{defaultContent.nativeType.componentType}}}{{/if}}>> __validations = this.validatorFactory.getValidator().validate({{{responseVar}}}, {{{@root.validationPackage}}}.Response.class);
 if (!__validations.isEmpty()) {
 	{{>hooks/beanValidationResponseViolation responseBuilderVar='__response' violationsVar='__validations' operation=.}}
 }

--- a/packages/java-jaxrs-server/templates/frag/operationServiceVars.hbs
+++ b/packages/java-jaxrs-server/templates/frag/operationServiceVars.hbs
@@ -1,13 +1,7 @@
 {{>frag/operationVars op=op jaxrs=false service=true}}
 {{#join 'op._parameters' ', '}}
 {{{op._parameters}}}
-{{#unless op.returnNativeType}}
-{{javax}}.ws.rs.core.Response.ResponseBuilder response
-{{/unless}}
 {{/join}}
 {{#join 'op._arguments' ', '}}
 {{{op._arguments}}}
-{{#unless op.returnNativeType}}
-response
-{{/unless}}
 {{/join}}

--- a/packages/java-jaxrs-server/templates/frag/responseWrapper.hbs
+++ b/packages/java-jaxrs-server/templates/frag/responseWrapper.hbs
@@ -1,0 +1,70 @@
+{{#if @root.useLombok}}
+@lombok.Getter
+@lombok.Setter
+{{/if}}
+public static class {{className name}} {
+
+{{#if bodyNativeType}}
+	private {{{bodyNativeType}}} body;
+{{/if}}
+{{#each headers}}
+	private {{{nativeType}}} {{identifier name}};
+{{/each}}
+
+{{#join '_parameters' ', '}}
+{{#if bodyNativeType}}
+{{{bodyNativeType}}} body
+{{/if}}
+{{#each headers}}
+{{#if required}}
+{{{nativeType}}} {{identifier name}}
+{{/if}}
+{{/each}}
+{{/join}}
+	public {{className name}}({{{_parameters}}}) {
+		{{#if bodyNativeType}}
+		this.body = body;
+		{{/if}}
+		{{#each headers}}
+		{{#if required}}
+		this.{{identifier name}} = {{identifier name}};
+		{{/if}}
+		{{/each}}
+	}
+
+{{#if bodyNativeType}}
+	{{#unless @root.useLombok}}
+	public {{{bodyNativeType}}} getBody() {
+		return this.body;
+	}
+
+	public void setBody({{{bodyNativeType}}} body) {
+		this.body = body;
+	}
+
+	{{/unless}}
+	public {{className name}} body({{{bodyNativeType}}} body) {
+		setBody(body);
+		return this;
+	}
+
+{{/if}}
+{{#each headers}}
+	{{#unless @root.useLombok}}
+	public {{{nativeType}}} {{getter .}}() {
+		return this.{{identifier name}};
+	}
+
+	public void {{setter .}}({{{nativeType}}} {{identifier name}}) {
+		this.{{identifier name}} = {{identifier name}};
+	}
+
+	{{/unless}}
+	public {{className ../name}} {{identifier name}}({{{nativeType}}} {{identifier name}}) {
+		{{setter .}}({{identifier name}});
+		return this;
+	}
+
+{{/each}}
+}
+

--- a/packages/java-jaxrs-server/templates/pom.hbs
+++ b/packages/java-jaxrs-server/templates/pom.hbs
@@ -28,7 +28,7 @@
 		{{/if}}
 		{{/if}}
 		{{#if useLombok}}
-		<lombok.version>{{lookup maven.versions 'lombok' '1.18.42'}}</lombok.version>
+		<lombok.version>{{lookup maven.versions 'lombok' '1.18.46'}}</lombok.version>
 		{{/if}}
 		{{>hooks/pomProperties}}
 	</properties>

--- a/packages/typescript-fetch-client2/templates/frag/apiResponseContent.hbs
+++ b/packages/typescript-fetch-client2/templates/frag/apiResponseContent.hbs
@@ -30,7 +30,10 @@ return {
 {{#if response.headers}}
 	headers: {
 {{#each response.headers}}
-		{{identifier name}}: response.headers.get({{{stringLiteral serializedName}}}) ?? undefined,
+{{#set '__headerValue'}}
+response.headers.get({{{stringLiteral serializedName}}})
+{{/set}}
+		{{identifier name}}: {{{__headerValue}}} ? {{>frag/stringToSchema value=__headerValue}} ?? undefined : undefined,
 {{/each}}
 	},
 {{/if}}

--- a/packages/typescript-fetch-client2/templates/frag/stringToSchema.hbs
+++ b/packages/typescript-fetch-client2/templates/frag/stringToSchema.hbs
@@ -1,0 +1,22 @@
+{{!--  
+@param value the expression containing the value
+@param this the CodegenParameter
+--}}
+{{#if (isDateTime)}}
+{{#ifeq @root.dateApproach 'native'}}
+new Date({{{value}}})
+{{~else}}
+{{{value}}}
+{{~/ifeq}}
+{{~else or (isDate) (isTime)}}
+{{{value}}}
+{{~else or (isObject) (isArray)}}
+{{!-- TODO we need to support explode etc --}}
+{{{value}}}
+{{~else if (isNumeric)}}
+Number({{{value}}})
+{{~else if (isBoolean)}}
+({{{value}}} && {{{value}}}.toLowerCase() === 'true')
+{{~else}}
+{{{value}}}
+{{~/if~}}

--- a/packages/typescript-fetch-node-client2/templates/frag/apiResponseContent.hbs
+++ b/packages/typescript-fetch-node-client2/templates/frag/apiResponseContent.hbs
@@ -30,7 +30,10 @@ return {
 {{#if response.headers}}
 	headers: {
 {{#each response.headers}}
-		{{identifier name}}: response.headers.get({{{stringLiteral serializedName}}}) ?? undefined,
+{{#set '__headerValue'}}
+response.headers.get({{{stringLiteral serializedName}}})
+{{/set}}
+		{{identifier name}}: {{{__headerValue}}} ? {{>frag/stringToSchema value=__headerValue}} ?? undefined : undefined,
 {{/each}}
 	},
 {{/if}}


### PR DESCRIPTION
jaxrs server: apply wrapped response headers

This was built with Cache control headers in mind.

I had to add some statements to work around the automatically applied headers that the initial ResponseBuilder used as when you have competing headers, the stricter one is used (for cache control). 

A quirk that I currently have is trying to use If-Modified-Since. If you used fetch with `cache: 'default'` you don't need your app to manage this. I'm not sure where to document that or if we would run into any issues. That's why I've left the fetch client alone and chose not to implement this manually ourselves.

Tests were generated by Claude.

If you want to see how I've implemented it have a look at the feature/cached-headers on the gin-backend project. 