### PR TITLE
feat(java-jaxrs-common): improve code generation for comparison methods in POJOs

### DIFF
--- a/.changeset/polite-dingos-follow.md
+++ b/.changeset/polite-dingos-follow.md
@@ -1,0 +1,5 @@
+---
+"@openapi-generator-plus/java-jaxrs-generator-common": minor
+---
+
+Fix byte array comparison and improve use of Lombok code generation in POJOs.

--- a/packages/java-jaxrs-common/src/__tests__/pojo-equals.spec.ts
+++ b/packages/java-jaxrs-common/src/__tests__/pojo-equals.spec.ts
@@ -30,6 +30,25 @@ test('pojo with useLombok uses @EqualsAndHashCode annotation instead of manual e
 	})
 })
 
+test('pojo with boolean property starting with “is” uses correct setter method name in Lombok mode', async() => {
+	const result = await createCodegenResult(path.resolve(__dirname, 'pojo-equals.yml'), {
+		...DEFAULT_CONFIG,
+		useLombok: true,
+	}, myCreateGenerator)
+	await testGenerate(result, {
+		testName: 'pojo-equals/boolean-with-is-prefix',
+		postProcess: async(basePath) => {
+			const content = await fs.promises.readFile(path.join(basePath, MODEL_PATH, 'FileData.java'), 'utf-8')
+			expect(content).toContain('setImage(isImage)')
+			expect(content).not.toContain('setIsImage(isImage)')
+			expect(content).toContain('setPasswordProtect(passwordProtect)')
+			expect(content).not.toContain('setPasswordProtect(isPasswordProtect)')
+			expect(content).not.toContain('setIsPasswordProtect(passwordProtect)')
+			expect(content).not.toContain('setIsPasswordProtect(isPasswordProtect)')
+		},
+	})
+})
+
 test('pojo with binary property uses Arrays.equals in equals method', async() => {
 	const result = await createCodegenResult(path.resolve(__dirname, 'pojo-equals.yml'), DEFAULT_CONFIG, myCreateGenerator)
 	await testGenerate(result, {

--- a/packages/java-jaxrs-common/src/__tests__/pojo-equals.spec.ts
+++ b/packages/java-jaxrs-common/src/__tests__/pojo-equals.spec.ts
@@ -30,25 +30,6 @@ test('pojo with useLombok uses @EqualsAndHashCode annotation instead of manual e
 	})
 })
 
-test('pojo with boolean property starting with “is” uses correct setter method name in Lombok mode', async() => {
-	const result = await createCodegenResult(path.resolve(__dirname, 'pojo-equals.yml'), {
-		...DEFAULT_CONFIG,
-		useLombok: true,
-	}, myCreateGenerator)
-	await testGenerate(result, {
-		testName: 'pojo-equals/boolean-with-is-prefix',
-		postProcess: async(basePath) => {
-			const content = await fs.promises.readFile(path.join(basePath, MODEL_PATH, 'FileData.java'), 'utf-8')
-			expect(content).toContain('setImage(isImage)')
-			expect(content).not.toContain('setIsImage(isImage)')
-			expect(content).toContain('setPasswordProtect(passwordProtect)')
-			expect(content).not.toContain('setPasswordProtect(isPasswordProtect)')
-			expect(content).not.toContain('setIsPasswordProtect(passwordProtect)')
-			expect(content).not.toContain('setIsPasswordProtect(isPasswordProtect)')
-		},
-	})
-})
-
 test('pojo with binary property uses Arrays.equals in equals method', async() => {
 	const result = await createCodegenResult(path.resolve(__dirname, 'pojo-equals.yml'), DEFAULT_CONFIG, myCreateGenerator)
 	await testGenerate(result, {

--- a/packages/java-jaxrs-common/src/__tests__/pojo-equals.spec.ts
+++ b/packages/java-jaxrs-common/src/__tests__/pojo-equals.spec.ts
@@ -1,0 +1,48 @@
+import { testGenerate } from '@openapi-generator-plus/generator-common/dist/testing'
+import { createCodegenResult } from '@openapi-generator-plus/testing'
+import createGenerator from '..'
+import path from 'path'
+import fs from 'fs'
+import { CodegenConfig, CodegenGeneratorConstructor, CodegenGeneratorType } from '@openapi-generator-plus/types'
+
+const myCreateGenerator: CodegenGeneratorConstructor = (config, context) => ({
+	...createGenerator(config, context),
+	generatorType: () => CodegenGeneratorType.SERVER,
+})
+
+const DEFAULT_CONFIG: CodegenConfig = {}
+
+const MODEL_PATH = path.join('com', 'example', 'model')
+
+test('pojo with useLombok uses @EqualsAndHashCode annotation instead of manual equals/hashCode', async() => {
+	const result = await createCodegenResult(path.resolve(__dirname, 'pojo-equals.yml'), {
+		...DEFAULT_CONFIG,
+		useLombok: true,
+	}, myCreateGenerator)
+	await testGenerate(result, {
+		testName: 'pojo-equals/lombok',
+		postProcess: async(basePath) => {
+			const content = await fs.promises.readFile(path.join(basePath, MODEL_PATH, 'FileData.java'), 'utf-8')
+			expect(content).toContain('@lombok.EqualsAndHashCode')
+			expect(content).not.toContain('public boolean equals(')
+			expect(content).not.toContain('public int hashCode(')
+		},
+	})
+})
+
+test('pojo with binary property uses Arrays.equals in equals method', async() => {
+	const result = await createCodegenResult(path.resolve(__dirname, 'pojo-equals.yml'), DEFAULT_CONFIG, myCreateGenerator)
+	await testGenerate(result, {
+		testName: 'pojo-equals/binary',
+		postProcess: async(basePath) => {
+			const content = await fs.promises.readFile(path.join(basePath, MODEL_PATH, 'FileData.java'), 'utf-8')
+			expect(content).toContain('public boolean equals(')
+			expect(content).toContain('public int hashCode(')
+			expect(content).not.toContain('@lombok.EqualsAndHashCode')
+			expect(content).toContain('java.util.Arrays.equals(this.content,')
+			expect(content).not.toContain('java.util.Objects.equals(this.content,')
+			expect(content).toContain('java.util.Objects.equals(this.name,')
+			expect(content).not.toContain('java.util.Arrays.equals(this.name,')
+		},
+	})
+})

--- a/packages/java-jaxrs-common/src/__tests__/pojo-equals.spec.ts
+++ b/packages/java-jaxrs-common/src/__tests__/pojo-equals.spec.ts
@@ -41,8 +41,28 @@ test('pojo with binary property uses Arrays.equals in equals method', async() =>
 			expect(content).not.toContain('@lombok.EqualsAndHashCode')
 			expect(content).toContain('java.util.Arrays.equals(this.content,')
 			expect(content).not.toContain('java.util.Objects.equals(this.content,')
+			expect(content).toContain('java.util.Arrays.equals(this.checksum,')
+			expect(content).not.toContain('java.util.Objects.equals(this.checksum,')
 			expect(content).toContain('java.util.Objects.equals(this.name,')
 			expect(content).not.toContain('java.util.Arrays.equals(this.name,')
+		},
+	})
+})
+
+test('pojo with binary property using non-array native type uses Objects.equals in equals method', async() => {
+	const result = await createCodegenResult(path.resolve(__dirname, 'pojo-equals.yml'), {
+		...DEFAULT_CONFIG,
+		binaryRepresentation: 'java.nio.ByteBuffer',
+	}, myCreateGenerator)
+	await testGenerate(result, {
+		testName: 'pojo-equals/binary-non-array',
+		postProcess: async(basePath) => {
+			const content = await fs.promises.readFile(path.join(basePath, MODEL_PATH, 'FileData.java'), 'utf-8')
+			expect(content).toContain('public boolean equals(')
+			expect(content).toContain('java.util.Objects.equals(this.content,')
+			expect(content).not.toContain('java.util.Arrays.equals(this.content,')
+			expect(content).toContain('java.util.Arrays.equals(this.checksum,')
+			expect(content).not.toContain('java.util.Objects.equals(this.checksum,')
 		},
 	})
 })

--- a/packages/java-jaxrs-common/src/__tests__/pojo-equals.yml
+++ b/packages/java-jaxrs-common/src/__tests__/pojo-equals.yml
@@ -21,6 +21,7 @@ components:
       required:
         - name
         - content
+        - checksum
       properties:
         content:
           # This binary property (content) is implemented in Java as a byte[] property.
@@ -32,5 +33,10 @@ components:
           # option removes the generated equals() method in favour of a Lombok annotation.
           type: string
           format: binary
+        checksum:
+          # This is a non-binary schema with a native Java array type so we can assert that
+          # Arrays.equals() is selected based on nativeType rather than schema type.
+          type: string
+          x-java-type: byte[]
         name:
           type: string

--- a/packages/java-jaxrs-common/src/__tests__/pojo-equals.yml
+++ b/packages/java-jaxrs-common/src/__tests__/pojo-equals.yml
@@ -18,9 +18,18 @@ components:
   schemas:
     FileData:
       type: object
+      required:
+        - name
+        - content
+        - isImage
+        - passwordProtect
       properties:
         content:
           type: string
           format: binary
         name:
           type: string
+        isImage:
+          type: boolean
+        passwordProtect:
+          type: boolean

--- a/packages/java-jaxrs-common/src/__tests__/pojo-equals.yml
+++ b/packages/java-jaxrs-common/src/__tests__/pojo-equals.yml
@@ -1,0 +1,26 @@
+openapi: '3.0.3'
+info:
+  title: POJO equals test
+  version: '1.0'
+paths:
+  /files:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FileData'
+      responses:
+        200:
+          description: OK
+components:
+  schemas:
+    FileData:
+      type: object
+      properties:
+        content:
+          type: string
+          format: binary
+        name:
+          type: string

--- a/packages/java-jaxrs-common/src/__tests__/pojo-equals.yml
+++ b/packages/java-jaxrs-common/src/__tests__/pojo-equals.yml
@@ -21,15 +21,16 @@ components:
       required:
         - name
         - content
-        - isImage
-        - passwordProtect
       properties:
         content:
+          # This binary property (content) is implemented in Java as a byte[] property.
+          # The generated equals() method in the POJO compares each property to see if the instances are equal.
+          # Array properties (like byte[]) don't work with Objects.equals(), so this API definition
+          # allows pojo-equals.spec.ts to ensure that the array parameter is correctly compared using
+          # Arrays.equals() instead.
+          # Note that this isn't a problem when the useLombok configuration is applied, since that
+          # option removes the generated equals() method in favour of a Lombok annotation.
           type: string
           format: binary
         name:
           type: string
-        isImage:
-          type: boolean
-        passwordProtect:
-          type: boolean

--- a/packages/java-jaxrs-common/src/__tests__/pojo-lombok-boolean.spec.ts
+++ b/packages/java-jaxrs-common/src/__tests__/pojo-lombok-boolean.spec.ts
@@ -1,0 +1,34 @@
+import { testGenerate } from '@openapi-generator-plus/generator-common/dist/testing'
+import { createCodegenResult } from '@openapi-generator-plus/testing'
+import createGenerator from '..'
+import path from 'path'
+import fs from 'fs'
+import { CodegenConfig, CodegenGeneratorConstructor, CodegenGeneratorType } from '@openapi-generator-plus/types'
+
+const myCreateGenerator: CodegenGeneratorConstructor = (config, context) => ({
+	...createGenerator(config, context),
+	generatorType: () => CodegenGeneratorType.SERVER,
+})
+
+const DEFAULT_CONFIG: CodegenConfig = {}
+
+const MODEL_PATH = path.join('com', 'example', 'model')
+
+test('pojo with boolean property starting with “is” uses correct setter method name in Lombok mode', async() => {
+	const result = await createCodegenResult(path.resolve(__dirname, 'pojo-lombok-boolean.yml'), {
+		...DEFAULT_CONFIG,
+		useLombok: true,
+	}, myCreateGenerator)
+	await testGenerate(result, {
+		testName: 'pojo-equals/boolean-with-is-prefix',
+		postProcess: async(basePath) => {
+			const content = await fs.promises.readFile(path.join(basePath, MODEL_PATH, 'FileData.java'), 'utf-8')
+			expect(content).toContain('setImage(isImage)')
+			expect(content).not.toContain('setIsImage(isImage)')
+			expect(content).toContain('setPasswordProtect(passwordProtect)')
+			expect(content).not.toContain('setPasswordProtect(isPasswordProtect)')
+			expect(content).not.toContain('setIsPasswordProtect(passwordProtect)')
+			expect(content).not.toContain('setIsPasswordProtect(isPasswordProtect)')
+		},
+	})
+})

--- a/packages/java-jaxrs-common/src/__tests__/pojo-lombok-boolean.spec.ts
+++ b/packages/java-jaxrs-common/src/__tests__/pojo-lombok-boolean.spec.ts
@@ -25,6 +25,7 @@ test('pojo with boolean property starting with “is” uses correct setter meth
 			const content = await fs.promises.readFile(path.join(basePath, MODEL_PATH, 'FileData.java'), 'utf-8')
 			expect(content).toContain('setImage(isImage)')
 			expect(content).not.toContain('setIsImage(isImage)')
+			expect(content).toContain('setIsomorphic(isomorphic)')
 			expect(content).toContain('setPasswordProtect(passwordProtect)')
 			expect(content).not.toContain('setPasswordProtect(isPasswordProtect)')
 			expect(content).not.toContain('setIsPasswordProtect(passwordProtect)')

--- a/packages/java-jaxrs-common/src/__tests__/pojo-lombok-boolean.yml
+++ b/packages/java-jaxrs-common/src/__tests__/pojo-lombok-boolean.yml
@@ -27,5 +27,7 @@ components:
           type: string
         isImage:
           type: boolean
+        isomorphic:
+          type: boolean
         passwordProtect:
           type: boolean

--- a/packages/java-jaxrs-common/src/__tests__/pojo-lombok-boolean.yml
+++ b/packages/java-jaxrs-common/src/__tests__/pojo-lombok-boolean.yml
@@ -1,0 +1,31 @@
+openapi: '3.0.3'
+info:
+  title: POJO lombok boolean test
+  version: '1.0'
+paths:
+  /files:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FileData'
+      responses:
+        200:
+          description: OK
+components:
+  schemas:
+    FileData:
+      type: object
+      required:
+        - name
+        - isImage
+        - passwordProtect
+      properties:
+        name:
+          type: string
+        isImage:
+          type: boolean
+        passwordProtect:
+          type: boolean

--- a/packages/java-jaxrs-common/src/index.ts
+++ b/packages/java-jaxrs-common/src/index.ts
@@ -597,23 +597,30 @@ export default function createGenerator(config: CodegenConfig, context: JavaGene
 	
 		exportTemplates: async(outputPath, doc) => {
 			const hbs = Handlebars.create()
+
+			function lombokAwareIdentifier(property: CodegenProperty, isPrimitiveBool: boolean) {
+				const identifier = context.generator().toIdentifier(property.name)
+				if (generatorOptions.useLombok && isPrimitiveBool) {
+					return capitalize(identifier.replace(/^is(?=[A-Z])/, ''))
+				}
+				return capitalize(identifier)
+			}
 			
 			registerStandardHelpers(hbs, context)
 
 			hbs.registerHelper('getter', function(property: CodegenProperty) {
-				if (property.schema.schemaType === CodegenSchemaType.BOOLEAN && property.required && !property.nullable) {
-					return `is${capitalize(context.generator().toIdentifier(property.name))}`
+				const isPrimitiveBool = property.schema.schemaType === CodegenSchemaType.BOOLEAN && property.required && !property.nullable
+				const identifier = lombokAwareIdentifier(property, isPrimitiveBool)
+				if (isPrimitiveBool) {
+					return `is${capitalize(identifier)}`
 				} else {
-					return `get${capitalize(context.generator().toIdentifier(property.name))}`
+					return `get${capitalize(identifier)}`
 				}
 			})
 			hbs.registerHelper('setter', function(property: CodegenProperty) {
 				const isPrimitiveBool = property.schema.schemaType === CodegenSchemaType.BOOLEAN && property.required && !property.nullable
-				if (generatorOptions.useLombok && isPrimitiveBool) {
-					const identifier = context.generator().toIdentifier(property.name).replace(/^is(?=[A-Z])/, '')
-					return `set${capitalize(identifier)}`
-				}
-				return `set${capitalize(context.generator().toIdentifier(property.name))}`
+				const identifier = lombokAwareIdentifier(property, isPrimitiveBool)
+				return `set${capitalize(identifier)}`
 			})
 			hbs.registerHelper('escapeString', function(value: string) {
 				// eslint-disable-next-line prefer-rest-params

--- a/packages/java-jaxrs-common/src/index.ts
+++ b/packages/java-jaxrs-common/src/index.ts
@@ -3,7 +3,7 @@ import { CodegenOptionsJava } from './types'
 import path from 'path'
 import Handlebars from 'handlebars'
 import { loadTemplates, emit, registerStandardHelpers, sourcePosition, ActualHelperOptions } from '@openapi-generator-plus/handlebars-templates'
-import { javaLikeGenerator, ConstantStyle, options as javaLikeOptions, JavaLikeContext, EnumMemberStyle, isNativeArray, isPrimitiveBool, identifierCamelCase } from '@openapi-generator-plus/java-like-generator-helper'
+import { javaLikeGenerator, ConstantStyle, options as javaLikeOptions, JavaLikeContext, EnumMemberStyle, isNativeArray, getterMethodName, setterMethodName } from '@openapi-generator-plus/java-like-generator-helper'
 import { capitalize, commonGenerator, configBoolean, configNumber, configObject, configString, configStringArray, debugStringify, nullableConfigString } from '@openapi-generator-plus/generator-common'
 import * as idx from '@openapi-generator-plus/indexed-type'
 
@@ -600,33 +600,19 @@ export default function createGenerator(config: CodegenConfig, context: JavaGene
 
 			registerStandardHelpers(hbs, context)
 
-			/**
-			 * Lombok has special treatment for boolean properties that have a prefix of "is".
-			 * e.g. isAdmin would have @Getter isAdmin(), @Setter setAdmin()
-			 * instead of @Getter isIsAdmin(), @Setter setIsAdmin()
-			 */
-			function lombokAwareIdentifier(property: CodegenProperty) {
-				const identifier = context.generator().toIdentifier(property.name)
-				if (!generatorOptions.useLombok) {
-					return identifier
-				}
-				if (!isPrimitiveBool(property)) {
-					return identifier
-				}
-				return identifierCamelCase(identifier.replace(/^is(?=[A-Z])/, ''))
-			}
-
 			hbs.registerHelper('getter', function(property: CodegenProperty) {
-				const identifier = lombokAwareIdentifier(property)
-				if (isPrimitiveBool(property)) {
-					return `is${capitalize(identifier)}`
-				} else {
-					return `get${capitalize(identifier)}`
-				}
+				return getterMethodName({
+					property: property,
+					propertyName: context.generator().toIdentifier(property.name),
+					useLombok: generatorOptions.useLombok,
+				})
 			})
 			hbs.registerHelper('setter', function(property: CodegenProperty) {
-				const identifier = lombokAwareIdentifier(property)
-				return `set${capitalize(identifier)}`
+				return setterMethodName({
+					property: property,
+					propertyName: context.generator().toIdentifier(property.name),
+					useLombok: generatorOptions.useLombok,
+				})
 			})
 			hbs.registerHelper('isNativeArray', function(nativeType: CodegenNativeType | string | null) {
 				return isNativeArray(nativeType)

--- a/packages/java-jaxrs-common/src/index.ts
+++ b/packages/java-jaxrs-common/src/index.ts
@@ -3,7 +3,7 @@ import { CodegenOptionsJava } from './types'
 import path from 'path'
 import Handlebars from 'handlebars'
 import { loadTemplates, emit, registerStandardHelpers, sourcePosition, ActualHelperOptions } from '@openapi-generator-plus/handlebars-templates'
-import { javaLikeGenerator, ConstantStyle, options as javaLikeOptions, JavaLikeContext, EnumMemberStyle } from '@openapi-generator-plus/java-like-generator-helper'
+import { javaLikeGenerator, ConstantStyle, options as javaLikeOptions, JavaLikeContext, EnumMemberStyle, isNativeArray } from '@openapi-generator-plus/java-like-generator-helper'
 import { capitalize, commonGenerator, configBoolean, configNumber, configObject, configString, configStringArray, debugStringify, nullableConfigString } from '@openapi-generator-plus/generator-common'
 import * as idx from '@openapi-generator-plus/indexed-type'
 
@@ -621,6 +621,9 @@ export default function createGenerator(config: CodegenConfig, context: JavaGene
 				const isPrimitiveBool = property.schema.schemaType === CodegenSchemaType.BOOLEAN && property.required && !property.nullable
 				const identifier = lombokAwareIdentifier(property, isPrimitiveBool)
 				return `set${capitalize(identifier)}`
+			})
+			hbs.registerHelper('isNativeArray', function(nativeType: CodegenNativeType | string | null) {
+				return isNativeArray(nativeType)
 			})
 			hbs.registerHelper('escapeString', function(value: string) {
 				// eslint-disable-next-line prefer-rest-params

--- a/packages/java-jaxrs-common/src/index.ts
+++ b/packages/java-jaxrs-common/src/index.ts
@@ -608,6 +608,11 @@ export default function createGenerator(config: CodegenConfig, context: JavaGene
 				}
 			})
 			hbs.registerHelper('setter', function(property: CodegenProperty) {
+				const isPrimitiveBool = property.schema.schemaType === CodegenSchemaType.BOOLEAN && property.required && !property.nullable
+				if (generatorOptions.useLombok && isPrimitiveBool) {
+					const identifier = context.generator().toIdentifier(property.name).replace(/^is(?=[A-Z])/, '')
+					return `set${capitalize(identifier)}`
+				}
 				return `set${capitalize(context.generator().toIdentifier(property.name))}`
 			})
 			hbs.registerHelper('escapeString', function(value: string) {

--- a/packages/java-jaxrs-common/src/index.ts
+++ b/packages/java-jaxrs-common/src/index.ts
@@ -3,7 +3,7 @@ import { CodegenOptionsJava } from './types'
 import path from 'path'
 import Handlebars from 'handlebars'
 import { loadTemplates, emit, registerStandardHelpers, sourcePosition, ActualHelperOptions } from '@openapi-generator-plus/handlebars-templates'
-import { javaLikeGenerator, ConstantStyle, options as javaLikeOptions, JavaLikeContext, EnumMemberStyle, isNativeArray } from '@openapi-generator-plus/java-like-generator-helper'
+import { javaLikeGenerator, ConstantStyle, options as javaLikeOptions, JavaLikeContext, EnumMemberStyle, isNativeArray, isPrimitiveBool, identifierCamelCase } from '@openapi-generator-plus/java-like-generator-helper'
 import { capitalize, commonGenerator, configBoolean, configNumber, configObject, configString, configStringArray, debugStringify, nullableConfigString } from '@openapi-generator-plus/generator-common'
 import * as idx from '@openapi-generator-plus/indexed-type'
 
@@ -598,28 +598,34 @@ export default function createGenerator(config: CodegenConfig, context: JavaGene
 		exportTemplates: async(outputPath, doc) => {
 			const hbs = Handlebars.create()
 
-			function lombokAwareIdentifier(property: CodegenProperty, isPrimitiveBool: boolean) {
-				const identifier = context.generator().toIdentifier(property.name)
-				if (generatorOptions.useLombok && isPrimitiveBool) {
-					return capitalize(identifier.replace(/^is(?=[A-Z])/, ''))
-				}
-				return capitalize(identifier)
-			}
-			
 			registerStandardHelpers(hbs, context)
 
+			/**
+			 * Lombok has special treatment for boolean properties that have a prefix of "is".
+			 * e.g. isAdmin would have @Getter isAdmin(), @Setter setAdmin()
+			 * instead of @Getter isIsAdmin(), @Setter setIsAdmin()
+			 */
+			function lombokAwareIdentifier(property: CodegenProperty) {
+				const identifier = context.generator().toIdentifier(property.name)
+				if (!generatorOptions.useLombok) {
+					return identifier
+				}
+				if (!isPrimitiveBool(property)) {
+					return identifier
+				}
+				return identifierCamelCase(identifier.replace(/^is(?=[A-Z])/, ''))
+			}
+
 			hbs.registerHelper('getter', function(property: CodegenProperty) {
-				const isPrimitiveBool = property.schema.schemaType === CodegenSchemaType.BOOLEAN && property.required && !property.nullable
-				const identifier = lombokAwareIdentifier(property, isPrimitiveBool)
-				if (isPrimitiveBool) {
+				const identifier = lombokAwareIdentifier(property)
+				if (isPrimitiveBool(property)) {
 					return `is${capitalize(identifier)}`
 				} else {
 					return `get${capitalize(identifier)}`
 				}
 			})
 			hbs.registerHelper('setter', function(property: CodegenProperty) {
-				const isPrimitiveBool = property.schema.schemaType === CodegenSchemaType.BOOLEAN && property.required && !property.nullable
-				const identifier = lombokAwareIdentifier(property, isPrimitiveBool)
+				const identifier = lombokAwareIdentifier(property)
 				return `set${capitalize(identifier)}`
 			})
 			hbs.registerHelper('isNativeArray', function(nativeType: CodegenNativeType | string | null) {

--- a/packages/java-jaxrs-common/templates/frag/pojoProperty.hbs
+++ b/packages/java-jaxrs-common/templates/frag/pojoProperty.hbs
@@ -2,9 +2,9 @@
 {{>frag/propertyStatusAnnotations}}
 public {{{chainClassName}}} {{identifier name}}({{{nativeType}}} {{identifier name}}) {
 	{{#if nullable}}
-	set{{capitalize (identifier name)}}({{identifier name}} != null ? java.util.Optional.of({{identifier name}}) : java.util.Optional.empty());
+	{{setter .}}({{identifier name}} != null ? java.util.Optional.of({{identifier name}}) : java.util.Optional.empty());
 	{{else}}
-	set{{capitalize (identifier name)}}({{identifier name}});
+	{{setter .}}({{identifier name}});
 	{{/if}}
 	return this;
 }

--- a/packages/java-jaxrs-common/templates/frag/pojoUtilities.hbs
+++ b/packages/java-jaxrs-common/templates/frag/pojoUtilities.hbs
@@ -14,10 +14,10 @@ public boolean equals(java.lang.Object o) {
 	{{/if}}
 {{#if (isWrapper)}}
 	{{className name}} {{identifier name}} = ({{className name}}) o;
-	return {{#if (isBinary)}}java.util.Arrays.equals{{else if (isFile)}}java.util.Arrays.equals{{else}}java.util.Objects.equals{{/if}}(this.{{identifier property.name}}, {{identifier name}}.{{identifier property.name}});
+	return {{#if (isNativeArray property.nativeType)}}java.util.Arrays.equals{{else}}java.util.Objects.equals{{/if}}(this.{{identifier property.name}}, {{identifier name}}.{{identifier property.name}});
 	{{else if properties}}
 	{{className name}} {{identifier name}} = ({{className name}}) o;
-	return {{#each properties}}{{#if (isBinary)}}java.util.Arrays.equals{{else if (isFile)}}java.util.Arrays.equals{{else}}java.util.Objects.equals{{/if}}(this.{{identifier name}}, {{identifier ../name}}.{{identifier name}}){{#hasMore}}
+	return {{#each properties}}{{#if (isNativeArray nativeType)}}java.util.Arrays.equals{{else}}java.util.Objects.equals{{/if}}(this.{{identifier name}}, {{identifier ../name}}.{{identifier name}}){{#hasMore}}
 			&& {{/hasMore}}{{/each}};
 {{else}}
 	return true;

--- a/packages/java-jaxrs-common/templates/frag/pojoUtilities.hbs
+++ b/packages/java-jaxrs-common/templates/frag/pojoUtilities.hbs
@@ -1,3 +1,4 @@
+{{#unless @root.useLombok}}
 @java.lang.Override
 public boolean equals(java.lang.Object o) {
 	if (this == o) {
@@ -27,6 +28,7 @@ public boolean equals(java.lang.Object o) {
 public int hashCode() {
 	return {{#if parents}}31 * super.hashCode() + {{/if}}java.util.Objects.hash({{#if (isWrapper)}}this.{{identifier property.name}}{{else}}{{#each properties}}this.{{identifier name}}{{#hasMore}}, {{/hasMore}}{{/each}}{{/if}});
 }
+{{/unless}}
 
 @java.lang.Override
 public java.lang.String toString() {

--- a/packages/java-jaxrs-common/templates/frag/pojoUtilities.hbs
+++ b/packages/java-jaxrs-common/templates/frag/pojoUtilities.hbs
@@ -13,10 +13,10 @@ public boolean equals(java.lang.Object o) {
 	{{/if}}
 {{#if (isWrapper)}}
 	{{className name}} {{identifier name}} = ({{className name}}) o;
-	return java.util.Objects.equals(this.{{identifier property.name}}, {{identifier name}}.{{identifier property.name}});
+	return {{#if (isBinary)}}java.util.Arrays.equals{{else if (isFile)}}java.util.Arrays.equals{{else}}java.util.Objects.equals{{/if}}(this.{{identifier property.name}}, {{identifier name}}.{{identifier property.name}});
 	{{else if properties}}
 	{{className name}} {{identifier name}} = ({{className name}}) o;
-	return {{#each properties}}java.util.Objects.equals(this.{{identifier name}}, {{identifier ../name}}.{{identifier name}}){{#hasMore}}
+	return {{#each properties}}{{#if (isBinary)}}java.util.Arrays.equals{{else if (isFile)}}java.util.Arrays.equals{{else}}java.util.Objects.equals{{/if}}(this.{{identifier name}}, {{identifier ../name}}.{{identifier name}}){{#hasMore}}
 			&& {{/hasMore}}{{/each}};
 {{else}}
 	return true;

--- a/packages/java-jaxrs-common/templates/pojo.hbs
+++ b/packages/java-jaxrs-common/templates/pojo.hbs
@@ -4,6 +4,9 @@ package {{modelPackage}};
 {{>frag/pojoDocumentation}}
 {{>generatedAnnotation}}
 {{>frag/pojoHeader}}
+{{#if @root.useLombok}}
+@lombok.EqualsAndHashCode{{#if parents}}(callSuper = false){{/if}}
+{{/if}}
 public {{#if abstract}}abstract {{/if}}class {{className name}}{{#if parents}} extends {{#each parents}}{{{nativeType.concreteType}}}{{/each}}{{/if}} {{>frag/pojoImplements class=nativeType.nativeType}}{
 
 	{{>pojoContents}}

--- a/packages/java-jaxrs-common/templates/pojo.hbs
+++ b/packages/java-jaxrs-common/templates/pojo.hbs
@@ -5,7 +5,7 @@ package {{modelPackage}};
 {{>generatedAnnotation}}
 {{>frag/pojoHeader}}
 {{#if @root.useLombok}}
-@lombok.EqualsAndHashCode{{#if parents}}(callSuper = false){{/if}}
+@lombok.EqualsAndHashCode{{#if parents}}(callSuper = true){{/if}}
 {{/if}}
 public {{#if abstract}}abstract {{/if}}class {{className name}}{{#if parents}} extends {{#each parents}}{{{nativeType.concreteType}}}{{/each}}{{/if}} {{>frag/pojoImplements class=nativeType.nativeType}}{
 

--- a/packages/java-jaxrs-common/templates/pojoNested.hbs
+++ b/packages/java-jaxrs-common/templates/pojoNested.hbs
@@ -1,7 +1,7 @@
 {{>frag/pojoDocumentation}}
 {{>frag/pojoHeader}}
 {{#if @root.useLombok}}
-@lombok.EqualsAndHashCode{{#if parents}}(callSuper = false){{/if}}
+@lombok.EqualsAndHashCode{{#if parents}}(callSuper = true){{/if}}
 {{/if}}
 public static {{#if abstract}}abstract {{/if}}class {{className name}}{{#if parents}} extends {{#each parents}}{{{nativeType.concreteType}}}{{/each}}{{/if}} {{>frag/pojoImplements class=nativeType.nativeType}}{
 

--- a/packages/java-jaxrs-common/templates/pojoNested.hbs
+++ b/packages/java-jaxrs-common/templates/pojoNested.hbs
@@ -1,5 +1,8 @@
 {{>frag/pojoDocumentation}}
 {{>frag/pojoHeader}}
+{{#if @root.useLombok}}
+@lombok.EqualsAndHashCode{{#if parents}}(callSuper = false){{/if}}
+{{/if}}
 public static {{#if abstract}}abstract {{/if}}class {{className name}}{{#if parents}} extends {{#each parents}}{{{nativeType.concreteType}}}{{/each}}{{/if}} {{>frag/pojoImplements class=nativeType.nativeType}}{
 
 	{{>pojoContents}}

--- a/packages/java-like/src/__tests__/native-array.spec.ts
+++ b/packages/java-like/src/__tests__/native-array.spec.ts
@@ -1,0 +1,28 @@
+import { isNativeArray } from '../index'
+
+test('isNativeArray returns true when a native type string ends with array brackets', () => {
+	expect(isNativeArray('byte[]')).toBe(true)
+	expect(isNativeArray('java.lang.String[]')).toBe(true)
+	expect(isNativeArray('byte[][]')).toBe(true)
+})
+
+test('isNativeArray returns false when a native type string is not a Java array', () => {
+	expect(isNativeArray('java.util.List<java.lang.String>')).toBe(false)
+	expect(isNativeArray('java.nio.ByteBuffer')).toBe(false)
+	expect(isNativeArray(undefined)).toBe(false)
+	expect(isNativeArray(null)).toBe(false)
+})
+
+test('isNativeArray accepts CodegenNativeType-like objects', () => {
+	expect(isNativeArray({
+		nativeType: 'byte[]',
+		serializedType: 'byte[]',
+		literalType: 'byte[]',
+		concreteType: 'byte[]',
+		parentType: 'byte[]',
+		componentType: null,
+		info: null,
+		toString: () => 'byte[]',
+		equals: () => false,
+	})).toBe(true)
+})

--- a/packages/java-like/src/index.ts
+++ b/packages/java-like/src/index.ts
@@ -1,4 +1,4 @@
-import { CodegenGenerator, CodegenSchemaType, CodegenConfig, CodegenGeneratorContext, CodegenSchemaPurpose } from '@openapi-generator-plus/types'
+import { CodegenGenerator, CodegenSchemaType, CodegenConfig, CodegenGeneratorContext, CodegenSchemaPurpose, CodegenNativeType } from '@openapi-generator-plus/types'
 import { pascalCase, camelCase, configString } from '@openapi-generator-plus/generator-common'
 import { constantCase } from 'change-case'
 import { commonGenerator } from '@openapi-generator-plus/generator-common'
@@ -35,6 +35,11 @@ export function classCamelCase(value: string): string {
 
 export function identifierCamelCase(value: string): string {
 	return identifierSafe(camelCase(identifierSafe(value)))
+}
+
+export function isNativeArray(nativeType: CodegenNativeType | string | null | undefined): boolean {
+	const nativeTypeString = typeof nativeType === 'string' ? nativeType : nativeType?.nativeType
+	return nativeTypeString !== undefined && nativeTypeString.trim().endsWith('[]')
 }
 
 export const enum ConstantStyle {

--- a/packages/java-like/src/index.ts
+++ b/packages/java-like/src/index.ts
@@ -1,5 +1,5 @@
 import { CodegenGenerator, CodegenSchemaType, CodegenConfig, CodegenGeneratorContext, CodegenSchemaPurpose, CodegenNativeType, CodegenProperty } from '@openapi-generator-plus/types'
-import { pascalCase, camelCase, configString } from '@openapi-generator-plus/generator-common'
+import { pascalCase, camelCase, configString, capitalize } from '@openapi-generator-plus/generator-common'
 import { constantCase } from 'change-case'
 import { commonGenerator } from '@openapi-generator-plus/generator-common'
 
@@ -44,6 +44,45 @@ export function isNativeArray(nativeType: CodegenNativeType | string | null | un
 
 export function isPrimitiveBool(property: CodegenProperty): boolean {
 	return property.schema.schemaType === CodegenSchemaType.BOOLEAN && property.required && !property.nullable
+}
+
+type BeanMethodOptions = {
+	propertyName: string
+	property: CodegenProperty
+	/** when generating code with `useLombok = true`, bean methods get special treatment.
+	 * See {@link lombokAwareBeanMethodPropertyName} below.
+	*/
+	useLombok?: boolean
+}
+
+/**
+ * Lombok has special treatment for boolean properties that have a prefix of "is".
+ * e.g. isAdmin would have `@Getter isAdmin()`, `@Setter setAdmin()`
+ * instead of `@Getter isIsAdmin()`, `@Setter setIsAdmin()`
+ */
+function lombokAwareBeanMethodPropertyName(options: BeanMethodOptions) {
+	if (!options.useLombok) {
+		return options.propertyName
+	}
+	if (!isPrimitiveBool(options.property)) {
+		return options.propertyName
+	}
+	const propertyNameMaybeWithoutIsPrefix = options.propertyName.replace(/^is(?=[A-Z])/, '')
+	return identifierCamelCase(propertyNameMaybeWithoutIsPrefix)
+}
+
+export function setterMethodName(options: BeanMethodOptions) {
+	const propertyName = lombokAwareBeanMethodPropertyName(options)
+	return `set${capitalize(propertyName)}`
+}
+
+export function getterMethodName(options: BeanMethodOptions) {
+	const propertyName = lombokAwareBeanMethodPropertyName(options)
+	if (isPrimitiveBool(options.property)) {
+		return `is${capitalize(propertyName)}`
+	} else {
+		return `get${capitalize(propertyName)}`
+	}
 }
 
 export const enum ConstantStyle {

--- a/packages/java-like/src/index.ts
+++ b/packages/java-like/src/index.ts
@@ -1,4 +1,4 @@
-import { CodegenGenerator, CodegenSchemaType, CodegenConfig, CodegenGeneratorContext, CodegenSchemaPurpose, CodegenNativeType } from '@openapi-generator-plus/types'
+import { CodegenGenerator, CodegenSchemaType, CodegenConfig, CodegenGeneratorContext, CodegenSchemaPurpose, CodegenNativeType, CodegenProperty } from '@openapi-generator-plus/types'
 import { pascalCase, camelCase, configString } from '@openapi-generator-plus/generator-common'
 import { constantCase } from 'change-case'
 import { commonGenerator } from '@openapi-generator-plus/generator-common'
@@ -40,6 +40,10 @@ export function identifierCamelCase(value: string): string {
 export function isNativeArray(nativeType: CodegenNativeType | string | null | undefined): boolean {
 	const nativeTypeString = typeof nativeType === 'string' ? nativeType : nativeType?.nativeType
 	return nativeTypeString !== undefined && nativeTypeString.trim().endsWith('[]')
+}
+
+export function isPrimitiveBool(property: CodegenProperty): boolean {
+	return property.schema.schemaType === CodegenSchemaType.BOOLEAN && property.required && !property.nullable
 }
 
 export const enum ConstantStyle {


### PR DESCRIPTION
### Description
Fixes byte array comparison for file properties by using `java.util.Arrays.equals` instead of `java.util.Objects.equals`. Also use Lombok to generate the `equals` and `hashCode` methods in POJOs when `useLombok: true` so the correct utility classes are automatically used when comparing objects.