### PR TITLE
typescript-common: add support for customising the api namespace

### DIFF
--- a/packages/typescript-common/src/index.ts
+++ b/packages/typescript-common/src/index.ts
@@ -190,6 +190,7 @@ export function options(config: CodegenConfig, context: TypeScriptGeneratorConte
 		dateApproach,
 		blindDate: blindDateOptions,
 		esm: configBoolean(config, 'esm', false),
+		apiNamespace: configString(config, 'apiNamespace', 'Api'),
 	}
 
 	return options
@@ -387,7 +388,7 @@ export default function createGenerator(config: CodegenConfig, context: TypeScri
 		},
 		toNativeObjectType: function(options) {
 			const { scopedName } = options
-			let modelName = 'Api'
+			let modelName = generatorOptions.apiNamespace
 			for (const name of scopedName) {
 				modelName += `.${context.generator().toClassName(name)}`
 			}

--- a/packages/typescript-common/src/types.ts
+++ b/packages/typescript-common/src/types.ts
@@ -11,6 +11,7 @@ export interface CodegenOptionsTypeScript extends JavaLikeOptions {
 	dateApproach: DateApproach
 	blindDate: BlindDateOptions
 	esm: boolean | null
+	apiNamespace: string
 }
 
 export enum DateApproach {

--- a/packages/typescript-fetch-client/README.md
+++ b/packages/typescript-fetch-client/README.md
@@ -28,6 +28,7 @@ The available config file properties are:
 |`legacyUnnamespacedModelSupport`|`boolean`|Generate unnamespaced versions of the models.|`false`|
 |`includePolyfills`|`boolean`|Include polyfills for features that browsers might not support or support well.|`true`|
 |`esm`|`boolean`|Whether to output ESM-style code.|`false`|
+|`apiNamespace`|`string`|The name of the TypeScript namespace used to export all models.|`"Api"`|
 
 ### `blind-date`
 

--- a/packages/typescript-fetch-client/templates/api.hbs
+++ b/packages/typescript-fetch-client/templates/api.hbs
@@ -2,7 +2,7 @@
 
 import { Configuration } from "./configuration";
 import { BASE_PATH, COLLECTION_FORMATS, encodeURIPathSegment, FetchAPI, FetchArgs, BaseAPI, RequiredError, defaultFetch } from "./runtime";
-import { Api } from "./models";
+import { {{apiNamespace}} } from "./models";
 {{#ifeq dateApproach 'blind-date'}}
 import { LocalDateString, LocalTimeString, LocalDateTimeString, OffsetDateTimeString } from 'blind-date';
 {{/ifeq}}

--- a/packages/typescript-fetch-client/templates/models.hbs
+++ b/packages/typescript-fetch-client/templates/models.hbs
@@ -5,7 +5,7 @@ import { LocalDateString, LocalTimeString, LocalDateTimeString, OffsetDateTimeSt
 {{/ifeq}}
 {{>hooks/modelsImports}}
 
-export namespace Api {
+export namespace {{apiNamespace}} {
 {{>nestedModels}}
 }
 {{#if legacyUnnamespacedModelSupport}}
@@ -13,10 +13,10 @@ export namespace Api {
 {{#each schemas}}
 {{#if (isEnum)}}
 {{>frag/schemaDocumentation}}
-export import {{className name}} = Api.{{className name}}
+export import {{className name}} = {{apiNamespace}}.{{className name}}
 {{else}}
 {{>frag/schemaDocumentation}}
-export type {{className name}} = Api.{{className name}}
+export type {{className name}} = {{apiNamespace}}.{{className name}}
 {{/if}}
 
 {{/each}}

--- a/packages/typescript-fetch-client2/README.md
+++ b/packages/typescript-fetch-client2/README.md
@@ -113,6 +113,7 @@ The available config file properties are:
 |`legacyUnnamespacedModelSupport`|`boolean`|Generate unnamespaced versions of the models.|`false`|
 |`includePolyfills`|`boolean`|Include polyfills for features that browsers might not support or support well.|`true`|
 |`esm`|`boolean`|Whether to output ESM-style code.|`false`|
+|`apiNamespace`|`string`|The name of the TypeScript namespace used to export all models.|`"Api"`|
 
 ### `blind-date`
 

--- a/packages/typescript-fetch-client2/src/__tests__/api-namespace.spec.ts
+++ b/packages/typescript-fetch-client2/src/__tests__/api-namespace.spec.ts
@@ -1,0 +1,22 @@
+import { testGenerate } from '@openapi-generator-plus/generator-common/dist/testing'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { prepare, DEFAULT_CONFIG } from './common'
+
+test('apiNamespace config', async() => {
+	const result = await prepare('shadowed-model-v2.yml', {
+		...DEFAULT_CONFIG,
+		apiNamespace: 'ApiCustom',
+	})
+
+	let modelsContent = ''
+	await testGenerate(result, {
+		testName: 'api-namespace',
+		postProcess: async(basePath) => {
+			modelsContent = await fs.readFile(path.join(basePath, 'src', 'models.ts'), 'utf-8')
+		},
+	})
+
+	expect(modelsContent).toContain('export namespace ApiCustom {')
+	expect(modelsContent).not.toContain('export namespace Api {')
+}, 20000)

--- a/packages/typescript-fetch-client2/templates/models.hbs
+++ b/packages/typescript-fetch-client2/templates/models.hbs
@@ -7,7 +7,7 @@ import { LocalDateString, LocalTimeString, LocalDateTimeString, OffsetDateTimeSt
 
 type ValuesOf<T> = T[keyof T]
 
-export namespace Api {
+export namespace {{apiNamespace}} {
 {{>nestedModels}}
 }
 

--- a/packages/typescript-fetch-node-client/README.md
+++ b/packages/typescript-fetch-node-client/README.md
@@ -26,6 +26,7 @@ The available config file properties are:
 |`enumMemberStyle`|`"preserve"` \| `"constant"`|The style to use for enum member names: `preserve` _attempts_ to match the enum member name to the literal enum value from the spec; `constant` uses the `constantStyle` rules.|`"constant"`|
 |`legacyUnnamespacedModelSupport`|`boolean`|Generate unnamespaced versions of the models.|`false`|
 |`dateApproach`|`"native"\|"string"\|"blind-date"`|Whether to use `string` for date and time and `Date` for date-time, or just `string`, or whether to use [blind-date](https://npmjs.com/blind-date) for dates and times.|`native`|
+|`apiNamespace`|`string`|The name of the TypeScript namespace used to export all models.|`"Api"`|
 
 ### TypeScript
 

--- a/packages/typescript-fetch-node-client/src/__tests__/api-namespace.spec.ts
+++ b/packages/typescript-fetch-node-client/src/__tests__/api-namespace.spec.ts
@@ -1,0 +1,22 @@
+import { testGenerate } from '@openapi-generator-plus/generator-common/dist/testing'
+import { promises as fs } from 'fs'
+import path from 'path'
+import { prepare, DEFAULT_CONFIG } from './common'
+
+test('apiNamespace config', async() => {
+	const result = await prepare('shadowed-model-v2.yml', {
+		...DEFAULT_CONFIG,
+		apiNamespace: 'ApiCustom',
+	})
+
+	let modelsContent = ''
+	await testGenerate(result, {
+		testName: 'api-namespace',
+		postProcess: async(basePath) => {
+			modelsContent = await fs.readFile(path.join(basePath, 'src', 'models.ts'), 'utf-8')
+		},
+	})
+
+	expect(modelsContent).toContain('export namespace ApiCustom {')
+	expect(modelsContent).not.toContain('export namespace Api {')
+}, 20000)

--- a/packages/typescript-fetch-node-client/src/__tests__/shadowed-model-v2.yml
+++ b/packages/typescript-fetch-node-client/src/__tests__/shadowed-model-v2.yml
@@ -1,0 +1,21 @@
+swagger: '2.0'
+info:
+  title: Test
+  version: '1.0'
+paths: {}
+definitions:
+  Outer:
+    type: object
+    properties:
+      name:
+        type: string
+  Container:
+    type: object
+    properties:
+      outer:
+        allOf:
+          - $ref: '#/definitions/Outer'
+          - type: object
+            properties:
+              inner:
+                type: string


### PR DESCRIPTION
Previously the API namespace was hardcoded to `Api`.

If a project had several generated APIs, they would all be duelling over this `Api` name.

It makes sense to me to be able to customise this namespace.